### PR TITLE
fix mock BTC client for FP e2e test

### DIFF
--- a/testutil/mock_btc_client.go
+++ b/testutil/mock_btc_client.go
@@ -22,9 +22,17 @@ func NewMockBTCClient(cfg *btcclient.BTCConfig, logger *zap.Logger) (*MockBtcCli
 
 // GetBlockHeightByTimestamp overrides the BTCClient's GetBlockHeightByTimestamp method.
 func (c *MockBtcClient) GetBlockHeightByTimestamp(targetTimestamp uint64) (uint64, error) {
-	// has to be a small number so when FP e2e tests use it, the test can finish quickly
-	// if it's too large, it will result in unbounding of the delegation
-	return 10, nil
+	// by default, kValue is 6 and wValue is 20
+	//
+	// in out test, the two mock delegations has:
+	// - btcDel.StartHeight: is 1, btcDel.EndHeight: 101
+	// - btcDel.StartHeight: is 8, btcDel.EndHeight: 108
+	//
+	// so to avoid `QueryIsBlockBabylonFinalized` returning `ErrBtcStakingNotActivated` in test,
+	// we should return a height that's between [8+6, 101-20]
+	//
+	// so here we choose a number around the middle
+	return 50, nil
 }
 
 // this is used to determine when the BTC staking is activated. return 0 to


### PR DESCRIPTION
## Summary

context https://github.com/babylonlabs-io/finality-gadget/issues/1. this is a follow-up fix for https://github.com/babylonchain/babylon-finality-gadget/pull/63

after I added the changes in OP and Finality Gadget, I started to test with FP all together. But `TestOpMultipleFinalityProviders` failed with "Condition Never Satisfied" error at Line 
```
ctm.WaitForFpVoteAtHeight(t, fpList[0], targetBlockHeight)
```

digging deeper, I found
- `targetBlockHeight` is 128 but both FP only signed till block 102 via `SubmitBatchFinalitySigs` and `SubmitFinalitySig` is never entered
- both FPs only receives block height 1 in `finalitySigSubmissionLoop` by the chain poller
- "the poller retrieved the block from the consumer chain" logs only block 1 and 2 (for both FPs)
- chain poller failed to fetch block 103: `service/chain_poller.go:165	failed to query the consumer chain for the latest block	{"attempt": 5, "max_attempts": 5, "height": 103, "error": "not found"}`

then I found op verifier logs:
```
state.go:371:               ERROR[07-30|22:12:28.129] Derivation process critical error        role=verifier err="failed to check if block 79 to 80 is finalized on Babylon: BTC staking is not activated for the consumer chain"
```
this is b/c in `QueryIsBlockBabylonFinalized`, `btcblockHeight` is 10 (mocked return value) but `QueryEarliestActiveDelBtcHeight` returns 14 (i.e. 8+6), so `if btcblockHeight < earliestDelHeight` is met and returns ErrBtcStakingNotActivated

Thus, the solution is to return a value >= 14

## Test Plan
test with FP op e2e and passed