### PR TITLE
fix: delete db from grpc client

### DIFF
--- a/client/rpcclient.go
+++ b/client/rpcclient.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/babylonlabs-io/finality-gadget/db"
 	"github.com/babylonlabs-io/finality-gadget/proto"
 	"github.com/babylonlabs-io/finality-gadget/types"
 	"google.golang.org/grpc"
@@ -14,11 +13,9 @@ import (
 type FinalityGadgetGrpcClient struct {
 	client proto.FinalityGadgetClient
 	conn   *grpc.ClientConn
-	db     db.IDatabaseHandler
 }
 
 func NewFinalityGadgetGrpcClient(
-	db db.IDatabaseHandler,
 	remoteAddr string,
 ) (*FinalityGadgetGrpcClient, error) {
 	conn, err := grpc.NewClient(remoteAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -29,7 +26,6 @@ func NewFinalityGadgetGrpcClient(
 	gClient := &FinalityGadgetGrpcClient{
 		client: proto.NewFinalityGadgetClient(conn),
 		conn:   conn,
-		db:     db,
 	}
 
 	return gClient, nil

--- a/cmd/opfgd/start.go
+++ b/cmd/opfgd/start.go
@@ -88,7 +88,7 @@ func runStartCmd(ctx client.Context, cmd *cobra.Command, args []string) error {
 
 	// Create grpc client
 	hostAddr := "localhost:" + cfg.GRPCServerPort
-	client, err := rpcclient.NewFinalityGadgetGrpcClient(db, hostAddr)
+	client, err := rpcclient.NewFinalityGadgetGrpcClient(hostAddr)
 	if err != nil {
 		logger.Fatal("Error creating grpc client", zap.Error(err))
 		return fmt.Errorf("error creating grpc client: %v", err)


### PR DESCRIPTION
## Summary

A very small PR to delete db handler from grpc client, as this is only needed for the grpc server.

## Test plan

```
make test
```