### PR TITLE
feat: store BTC staking activated timestamp into DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ GIT_ROOT := $(shell git rev-parse --show-toplevel)
 
 mock-gen:
 	go install go.uber.org/mock/mockgen@latest
+	mockgen -source=db/interface.go -package mocks -destination $(MOCKS_DIR)/db_mock.go
 	mockgen -source=finalitygadget/expected_clients.go -package mocks -destination $(MOCKS_DIR)/expected_clients_mock.go
 
 test:

--- a/db/bbolt.go
+++ b/db/bbolt.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"math"
 	"time"
 
 	"github.com/babylonlabs-io/finality-gadget/types"
@@ -225,7 +226,7 @@ func (bb *BBoltHandler) GetActivatedTimestamp() (uint64, error) {
 		return nil
 	})
 	if err != nil {
-		return 0, err
+		return math.MaxUint64, err
 	}
 	return timestamp, nil
 }

--- a/db/bbolt_test.go
+++ b/db/bbolt_test.go
@@ -220,3 +220,38 @@ func TestQueryLatestFinalizedBlockNonExistent(t *testing.T) {
 	assert.Nil(t, latestBlock)
 	assert.NoError(t, err)
 }
+
+func TestGetActivatedTimestamp(t *testing.T) {
+	handler, cleanup := setupDB(t)
+	defer cleanup()
+
+	// Test when timestamp is not set
+	timestamp, err := handler.GetActivatedTimestamp()
+	assert.Equal(t, uint64(0), timestamp)
+	assert.Equal(t, types.ErrActivatedTimestampNotFound, err)
+
+	// Set timestamp
+	expectedTimestamp := uint64(1234567890)
+	err = handler.SaveActivatedTimestamp(expectedTimestamp)
+	assert.NoError(t, err)
+
+	// Test when timestamp is set
+	timestamp, err = handler.GetActivatedTimestamp()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTimestamp, timestamp)
+}
+
+func TestSaveActivatedTimestamp(t *testing.T) {
+	handler, cleanup := setupDB(t)
+	defer cleanup()
+
+	// Set timestamp
+	expectedTimestamp := uint64(1234567890)
+	err := handler.SaveActivatedTimestamp(expectedTimestamp)
+	assert.NoError(t, err)
+
+	// Verify timestamp was saved
+	timestamp, err := handler.GetActivatedTimestamp()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTimestamp, timestamp)
+}

--- a/db/interface.go
+++ b/db/interface.go
@@ -10,5 +10,7 @@ type IDatabaseHandler interface {
 	QueryIsBlockFinalizedByHeight(height uint64) (bool, error)
 	QueryIsBlockFinalizedByHash(hash string) (bool, error)
 	QueryLatestFinalizedBlock() (*types.Block, error)
+	GetActivatedTimestamp() (uint64, error)
+	SaveActivatedTimestamp(timestamp uint64) error
 	Close() error
 }

--- a/finalitygadget/finalitygadget.go
+++ b/finalitygadget/finalitygadget.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 	"time"
 
-	bbnClient "github.com/babylonlabs-io/babylon/client/client"
+	bbnclient "github.com/babylonlabs-io/babylon/client/client"
 	bbncfg "github.com/babylonlabs-io/babylon/client/config"
-	"github.com/babylonlabs-io/finality-gadget/bbnclient"
+	fgbbnclient "github.com/babylonlabs-io/finality-gadget/bbnclient"
 	"github.com/babylonlabs-io/finality-gadget/btcclient"
 	"github.com/babylonlabs-io/finality-gadget/config"
 	"github.com/babylonlabs-io/finality-gadget/cwclient"
@@ -51,11 +51,11 @@ func NewFinalityGadget(cfg *config.Config, db db.IDatabaseHandler, logger *zap.L
 	bbnConfig := bbncfg.DefaultBabylonConfig()
 	bbnConfig.RPCAddr = cfg.BBNRPCAddress
 	bbnConfig.ChainID = cfg.BBNChainID
-	babylonClient, err := bbnClient.New(
+	babylonClient, err := bbnclient.New(
 		&bbnConfig,
 		logger,
 	)
-	bbnClient := bbnclient.NewBabylonClient(babylonClient.QueryClient)
+	bbnClient := fgbbnclient.NewBabylonClient(babylonClient.QueryClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Babylon client: %w", err)
 	}
@@ -92,8 +92,8 @@ func NewFinalityGadget(cfg *config.Config, db db.IDatabaseHandler, logger *zap.L
 
 	lastProcessedHeight := uint64(0)
 	latestBlock, err := db.QueryLatestFinalizedBlock()
-	if err != nil {
-		return nil, err
+	if err != nil && !errors.Is(err, types.ErrBlockNotFound) {
+		return nil, fmt.Errorf("failed to query latest finalized block: %w", err)
 	}
 	if latestBlock != nil {
 		lastProcessedHeight = latestBlock.BlockHeight
@@ -252,65 +252,22 @@ func (fg *FinalityGadget) QueryBlockRangeBabylonFinalized(
 	return finalizedBlockHeight, nil
 }
 
-/* QueryBtcStakingActivatedTimestamp returns the timestamp when the BTC staking is activated
- *
- * - We will check for k deep and covenant quorum to mark a delegation as active
- * - So technically, activated time needs to be max of the following
- *	 - timestamp of Babylon block that BTC delegation receives covenant quorum
- *	 - timestamp of BTC block that BTC delegation's staking tx becomes k-deep
- * - But we don't have a Babylon API to find the earliest Babylon block where BTC delegation gets covenant quorum.
- *   and it's probably not a good idea to add this to Babylon, as this creates more coupling between Babylon and
- *   consumer. So waiting for covenant quorum can be implemented in a clean way only with Babylon side support.
- *   this will be considered as future work
- * - For now, we will use the k-deep BTC block timestamp for the activation timestamp
- * - The time diff issue is not burning. The time diff between pending and active only matters if FP equivocates
- *   during that time period
- *
- * returns math.MaxUint64, ErrBtcStakingNotActivated if the BTC staking is not activated
- */
+// QueryBtcStakingActivatedTimestamp retrieves BTC staking activation timestamp from the database
+// returns math.MaxUint64, error if any error occurs
 func (fg *FinalityGadget) QueryBtcStakingActivatedTimestamp() (uint64, error) {
-	// First, try to get the timestamp from the DB
+	// First, try to get the timestamp from the database
 	timestamp, err := fg.db.GetActivatedTimestamp()
 	if err != nil {
+		// If error is not found, try to query it from the bbnClient
+		if errors.Is(err, types.ErrActivatedTimestampNotFound) {
+			fg.logger.Debug("activation timestamp hasn't been set yet, querying from bbnClient...")
+			return fg.queryBtcStakingActivationTimestamp()
+		}
 		fg.logger.Error("Failed to get activated timestamp from database", zap.Error(err))
-	} else {
-		fg.logger.Debug("BTC staking activated timestamp found in database", zap.Uint64("timestamp", timestamp))
-		return timestamp, nil
-	}
-
-	// If there's an error (either activated timestamp not found or DB error), query from bbnClient
-	allFpPks, err := fg.queryAllFpBtcPubKeys()
-	if err != nil {
 		return math.MaxUint64, err
 	}
-	fg.logger.Debug("All consumer FP public keys", zap.Strings("allFpPks", allFpPks))
-
-	// check whether the btc staking is actived
-	earliestDelHeight, err := fg.bbnClient.QueryEarliestActiveDelBtcHeight(allFpPks)
-	// not activated yet
-	if earliestDelHeight == math.MaxUint64 {
-		return math.MaxUint64, types.ErrBtcStakingNotActivated
-	}
-	if err != nil {
-		return math.MaxUint64, err
-	}
-	fg.logger.Debug("Earliest active delegation height", zap.Uint64("height", earliestDelHeight))
-
-	// get the timestamp of the BTC height
-	btcBlockTimestamp, err := fg.btcClient.GetBlockTimestampByHeight(earliestDelHeight)
-	if err != nil {
-		return math.MaxUint64, err
-	}
-	fg.logger.Debug("BTC staking activated at", zap.Uint64("timestamp", btcBlockTimestamp))
-
-	// Save the timestamp to the DB
-	err = fg.db.SaveActivatedTimestamp(btcBlockTimestamp)
-	if err != nil {
-		fg.logger.Error("Failed to save activated timestamp to database", zap.Error(err))
-	}
-	fg.logger.Debug("Saved BTC staking activated timestamp to database", zap.Uint64("timestamp", btcBlockTimestamp))
-
-	return btcBlockTimestamp, nil
+	fg.logger.Debug("BTC staking activated timestamp found in database", zap.Uint64("timestamp", timestamp))
+	return timestamp, nil
 }
 
 func (fg *FinalityGadget) GetBlockByHeight(height uint64) (*types.Block, error) {
@@ -476,6 +433,65 @@ func (fg *FinalityGadget) handleBlock(ctx context.Context, latestFinalizedHeight
 	}
 
 	return nil
+}
+
+// Query the BTC staking activation timestamp from bbnClient
+// returns math.MaxUint64, ErrBtcStakingNotActivated if the BTC staking is not activated
+func (fg *FinalityGadget) queryBtcStakingActivationTimestamp() (uint64, error) {
+	allFpPks, err := fg.queryAllFpBtcPubKeys()
+	if err != nil {
+		return math.MaxUint64, err
+	}
+	fg.logger.Debug("All consumer FP public keys", zap.Strings("allFpPks", allFpPks))
+
+	earliestDelHeight, err := fg.bbnClient.QueryEarliestActiveDelBtcHeight(allFpPks)
+	if err != nil {
+		return math.MaxUint64, err
+	}
+	if earliestDelHeight == math.MaxUint64 {
+		return math.MaxUint64, types.ErrBtcStakingNotActivated
+	}
+	fg.logger.Debug("Earliest active delegation height", zap.Uint64("height", earliestDelHeight))
+
+	btcBlockTimestamp, err := fg.btcClient.GetBlockTimestampByHeight(earliestDelHeight)
+	if err != nil {
+		return math.MaxUint64, err
+	}
+	fg.logger.Debug("BTC staking activated at", zap.Uint64("timestamp", btcBlockTimestamp))
+
+	return btcBlockTimestamp, nil
+}
+
+// periodically check and update the BTC staking activation timestamp
+// Exit the goroutine once we've successfully saved the timestamp
+func (fg *FinalityGadget) MonitorBtcStakingActivation(ctx context.Context) {
+	ticker := time.NewTicker(fg.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			timestamp, err := fg.queryBtcStakingActivationTimestamp()
+			if err != nil {
+				if errors.Is(err, types.ErrBtcStakingNotActivated) {
+					fg.logger.Debug("BTC staking not yet activated, waiting...")
+					continue
+				}
+				fg.logger.Error("Failed to query BTC staking activation timestamp", zap.Error(err))
+				continue
+			}
+
+			err = fg.db.SaveActivatedTimestamp(timestamp)
+			if err != nil {
+				fg.logger.Error("Failed to save activated timestamp to database", zap.Error(err))
+				continue
+			}
+			fg.logger.Debug("Saved BTC staking activated timestamp to database", zap.Uint64("timestamp", timestamp))
+			return
+		}
+	}
 }
 
 func normalizeBlockHash(hash string) string {

--- a/finalitygadget/finalitygadget.go
+++ b/finalitygadget/finalitygadget.go
@@ -274,6 +274,7 @@ func (fg *FinalityGadget) QueryBtcStakingActivatedTimestamp() (uint64, error) {
 	if err != nil {
 		fg.logger.Error("Failed to get activated timestamp from database", zap.Error(err))
 	} else {
+		fg.logger.Debug("BTC staking activated timestamp found in database", zap.Uint64("timestamp", timestamp))
 		return timestamp, nil
 	}
 
@@ -307,6 +308,7 @@ func (fg *FinalityGadget) QueryBtcStakingActivatedTimestamp() (uint64, error) {
 	if err != nil {
 		fg.logger.Error("Failed to save activated timestamp to database", zap.Error(err))
 	}
+	fg.logger.Debug("Saved BTC staking activated timestamp to database", zap.Uint64("timestamp", btcBlockTimestamp))
 
 	return btcBlockTimestamp, nil
 }

--- a/finalitygadget/finalitygadget_test.go
+++ b/finalitygadget/finalitygadget_test.go
@@ -606,7 +606,6 @@ func TestQueryBtcStakingActivatedTimestamp(t *testing.T) {
 	mockBBNClient.EXPECT().QueryAllFpBtcPubKeys("consumer-chain-id").Return([]string{"pk1", "pk2"}, nil)
 	mockBBNClient.EXPECT().QueryEarliestActiveDelBtcHeight([]string{"pk1", "pk2"}).Return(uint64(100), nil)
 	mockBTCClient.EXPECT().GetBlockTimestampByHeight(uint64(100)).Return(uint64(1234567890), nil)
-	mockDbHandler.EXPECT().SaveActivatedTimestamp(uint64(1234567890)).Return(nil)
 
 	timestamp, err = mockFinalityGadget.QueryBtcStakingActivatedTimestamp()
 	require.NoError(t, err)

--- a/testutil/mocks/db_mock.go
+++ b/testutil/mocks/db_mock.go
@@ -67,18 +67,19 @@ func (mr *MockIDatabaseHandlerMockRecorder) CreateInitialSchema() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInitialSchema", reflect.TypeOf((*MockIDatabaseHandler)(nil).CreateInitialSchema))
 }
 
-// DeleteDB mocks base method.
-func (m *MockIDatabaseHandler) DeleteDB() error {
+// GetActivatedTimestamp mocks base method.
+func (m *MockIDatabaseHandler) GetActivatedTimestamp() (uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteDB")
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "GetActivatedTimestamp")
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// DeleteDB indicates an expected call of DeleteDB.
-func (mr *MockIDatabaseHandlerMockRecorder) DeleteDB() *gomock.Call {
+// GetActivatedTimestamp indicates an expected call of GetActivatedTimestamp.
+func (mr *MockIDatabaseHandlerMockRecorder) GetActivatedTimestamp() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDB", reflect.TypeOf((*MockIDatabaseHandler)(nil).DeleteDB))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActivatedTimestamp", reflect.TypeOf((*MockIDatabaseHandler)(nil).GetActivatedTimestamp))
 }
 
 // GetBlockByHash mocks base method.
@@ -109,6 +110,20 @@ func (m *MockIDatabaseHandler) GetBlockByHeight(height uint64) (*types.Block, er
 func (mr *MockIDatabaseHandlerMockRecorder) GetBlockByHeight(height any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByHeight", reflect.TypeOf((*MockIDatabaseHandler)(nil).GetBlockByHeight), height)
+}
+
+// InsertBlock mocks base method.
+func (m *MockIDatabaseHandler) InsertBlock(block *types.Block) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertBlock", block)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InsertBlock indicates an expected call of InsertBlock.
+func (mr *MockIDatabaseHandlerMockRecorder) InsertBlock(block any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertBlock", reflect.TypeOf((*MockIDatabaseHandler)(nil).InsertBlock), block)
 }
 
 // QueryIsBlockFinalizedByHash mocks base method.
@@ -156,16 +171,16 @@ func (mr *MockIDatabaseHandlerMockRecorder) QueryLatestFinalizedBlock() *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryLatestFinalizedBlock", reflect.TypeOf((*MockIDatabaseHandler)(nil).QueryLatestFinalizedBlock))
 }
 
-// InsertBlock mocks base method.
-func (m *MockIDatabaseHandler) InsertBlock(block *types.Block) error {
+// SaveActivatedTimestamp mocks base method.
+func (m *MockIDatabaseHandler) SaveActivatedTimestamp(timestamp uint64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InsertBlock", block)
+	ret := m.ctrl.Call(m, "SaveActivatedTimestamp", timestamp)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// InsertBlock indicates an expected call of InsertBlock.
-func (mr *MockIDatabaseHandlerMockRecorder) InsertBlock(block any) *gomock.Call {
+// SaveActivatedTimestamp indicates an expected call of SaveActivatedTimestamp.
+func (mr *MockIDatabaseHandlerMockRecorder) SaveActivatedTimestamp(timestamp any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertBlock", reflect.TypeOf((*MockIDatabaseHandler)(nil).InsertBlock), block)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveActivatedTimestamp", reflect.TypeOf((*MockIDatabaseHandler)(nil).SaveActivatedTimestamp), timestamp)
 }

--- a/types/errors.go
+++ b/types/errors.go
@@ -3,7 +3,8 @@ package types
 import "errors"
 
 var (
-	ErrBlockNotFound          = errors.New("block not found")
-	ErrNoFpHasVotingPower     = errors.New("no FP has voting power for the consumer chain")
-	ErrBtcStakingNotActivated = errors.New("BTC staking is not activated for the consumer chain")
+	ErrBlockNotFound              = errors.New("block not found")
+	ErrNoFpHasVotingPower         = errors.New("no FP has voting power for the consumer chain")
+	ErrBtcStakingNotActivated     = errors.New("BTC staking is not activated for the consumer chain")
+	ErrActivatedTimestampNotFound = errors.New("BTC staking activated timestamp not found")
 )


### PR DESCRIPTION
## Summary

This PR persists the BTC staking activated timestamp into DB, b/c it never changes, so it is better to store it in DB rather than perform the query to the Babylon node each time.

The origin comment https://github.com/babylonchain/babylon-finality-gadget/pull/61#discussion_r1689373331

## Test Plan

```
make lint
make test
```

Also, we can test it and check the finality-gadget log by running the integration deployment scripts:
```
git clone git@github.com:babylonlabs-io/babylon-integration-deployment.git
cd babylon-integration-deployment
git submodule init && git submodule update

make start-deployment-finality-gadget-integration-op-l2-demo

docker logs finality-gadget
```

```
2024-08-22T11:47:23.038878Z     debug   BTC staking activated at        {"timestamp": 1724327212}
2024-08-22T11:47:23.041548Z     debug   Saved BTC staking activated timestamp to database       {"timestamp": 1724327212}
2024-08-22T11:47:23.041625Z     info    Skipping block before BTC staking activation    {"block_height": 0}
2024-08-22T11:47:33.029236Z     debug   BTC staking activated timestamp found in database       {"timestamp": 1724327212}
```
