### PR TITLE
feat simple http server

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -8,4 +8,5 @@ FGContractAddress = "bbn1ghd753shjuwexxywmgs4xz7x2q732vcnkm6h2pyv9s6ah3hylvrqxxv
 BBNChainID = "euphrates-0.4.0"
 BBNRPCAddress = "https://rpc-euphrates.devnet.babylonchain.io"
 GRPCListener = "0.0.0.0:50051"
+HTTPListener = "0.0.0.0:8080"
 PollInterval = "10s"

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	BBNRPCAddress     string        `long:"bbn-rpc-address" description:"BabylonChain chain RPC address"`
 	DBFilePath        string        `long:"db-file-path" description:"path to the DB file"`
 	GRPCListener      string        `long:"grpc-listener" description:"host:port to listen for gRPC connections"`
+	HTTPListener      string        `long:"http-listener" description:"host:port to listen for HTTP connections"`
 	BitcoinDisableTLS bool          `long:"bitcoin-disable-tls" description:"disable TLS for RPC connections"`
 	PollInterval      time.Duration `long:"retry-interval" description:"interval in seconds to recheck Babylon finality of block"`
 }

--- a/ethl2client/ethl2client.go
+++ b/ethl2client/ethl2client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	eth "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
@@ -34,6 +35,11 @@ func NewEthL2Client(rpcHostAddr string) (*EthL2Client, error) {
 
 func (c *EthL2Client) HeaderByNumber(ctx context.Context, number *big.Int) (*eth.Header, error) {
 	return c.client.HeaderByNumber(ctx, number)
+}
+
+func (ec *EthL2Client) TransactionReceipt(ctx context.Context, txHash string) (*eth.Receipt, error) {
+	hash := common.HexToHash(txHash)
+	return ec.client.TransactionReceipt(ctx, hash)
 }
 
 func (c *EthL2Client) Close() {

--- a/finalitygadget/expected_clients.go
+++ b/finalitygadget/expected_clients.go
@@ -33,5 +33,6 @@ type ICosmWasmClient interface {
 
 type IEthL2Client interface {
 	HeaderByNumber(ctx context.Context, number *big.Int) (*eth.Header, error)
+	TransactionReceipt(ctx context.Context, txHash string) (*eth.Receipt, error)
 	Close()
 }

--- a/finalitygadget/finalitygadget.go
+++ b/finalitygadget/finalitygadget.go
@@ -306,32 +306,26 @@ func (fg *FinalityGadget) QueryTransactionStatus(txHash string) (*types.Transact
 	// get block info
 	ctx := context.Background()
 	txReceipt, err := fg.l2Client.TransactionReceipt(ctx, txHash)
-	fmt.Println("tx recept - block number:", txReceipt.BlockNumber)
 	if err != nil {
 		return nil, err
 	}
 	header, err := fg.l2Client.HeaderByNumber(ctx, txReceipt.BlockNumber)
-	fmt.Println("block hash:", header.Hash().Hex())
-	fmt.Println("block timestamp:", header.Time)
 	if err != nil {
 		return nil, err
 	}
 
 	// get babylon finalized info
 	isBabylonFinalized, err := fg.QueryIsBlockFinalizedByHeight(txReceipt.BlockNumber.Uint64())
-	fmt.Println("isBabylonFinalized", isBabylonFinalized)
 	if err != nil {
 		return nil, err
 	}
 
 	// get safe and finalized blocks
 	safeBlock, err := fg.l2Client.HeaderByNumber(ctx, big.NewInt(ethrpc.SafeBlockNumber.Int64()))
-	fmt.Println("safeBlock:", safeBlock.Number)
 	if err != nil {
 		return nil, err
 	}
 	finalizedBlock, err := fg.l2Client.HeaderByNumber(ctx, big.NewInt(ethrpc.FinalizedBlockNumber.Int64()))
-	fmt.Println("finalizedBlock:", finalizedBlock.Number)
 	if err != nil {
 		return nil, err
 	}
@@ -346,7 +340,8 @@ func (fg *FinalityGadget) QueryTransactionStatus(txHash string) (*types.Transact
 	} else {
 		status = types.FinalityStatusPending
 	}
-	fmt.Println("status:", status)
+
+	fg.logger.Debug("Transaction status", zap.String("block_hash", header.Hash().Hex()), zap.Uint64("block_height", header.Number.Uint64()), zap.String("tx_hash", txHash), zap.String("status", string(status)))
 
 	return &types.TransactionInfo{
 		TxHash:           txReceipt.TxHash.Hex(),

--- a/finalitygadget/interface.go
+++ b/finalitygadget/interface.go
@@ -72,4 +72,7 @@ type IFinalityGadget interface {
 
 	// QueryLatestFinalizedBlock returns the latest finalized block by querying the local db
 	QueryLatestFinalizedBlock() (*types.Block, error)
+
+	// QueryTransactionStatus returns the finality status of a transaction
+	QueryTransactionStatus(txHash string) (*types.TransactionInfo, error)
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/cometbft/cometbft v0.38.7
 	github.com/cosmos/cosmos-sdk v0.50.6
 	github.com/ethereum/go-ethereum v1.13.15
+	github.com/jsternberg/zap-logfmt v1.3.0
 	github.com/lightningnetwork/lnd v0.16.4-beta.rc1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
@@ -158,7 +159,6 @@ require (
 	github.com/jinzhu/copier v0.3.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jmhodges/levigo v1.0.0 // indirect
-	github.com/jsternberg/zap-logfmt v1.3.0 // indirect
 	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b // indirect
 	github.com/kkdai/bstream v1.0.0 // indirect
 	github.com/klauspost/compress v1.17.7 // indirect
@@ -190,7 +190,7 @@ require (
 	github.com/prometheus/procfs v0.13.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
-	github.com/rs/cors v1.8.3 // indirect
+	github.com/rs/cors v1.11.0 // indirect
 	github.com/rs/zerolog v1.32.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1048,6 +1048,8 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.8.3 h1:O+qNyWn7Z+F9M0ILBHgMVPuB1xTOucVd5gtaYyXBpRo=
 github.com/rs/cors v1.8.3/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/rs/cors v1.11.0 h1:0B9GE/r9Bc2UxRMMtymBkHTenPkHDv0CW4Y98GBY+po=
+github.com/rs/cors v1.11.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.32.0 h1:keLypqrlIjaFsbmJOBdB/qvyF8KEtCWHwobLp5l/mQ0=
 github.com/rs/zerolog v1.32.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=

--- a/server/http.go
+++ b/server/http.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+func (s *Server) txStatusHandler(w http.ResponseWriter, r *http.Request) {
+	// Extract query parameters
+	txHash := r.URL.Query().Get("hash")
+	fmt.Printf("txHash: %s\n", txHash)
+
+	// Get block from rpc.
+	txInfo, err := s.rpcServer.fg.QueryTransactionStatus(txHash)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	jsonResponse, err := json.Marshal(txInfo)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(jsonResponse)
+}
+
+func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
+	// Extract query parameters
+	name := r.URL.Query().Get("name")
+	age := r.URL.Query().Get("age")
+
+	// Respond with the parameters
+	response := fmt.Sprintf("Name: %s, Age: %s", name, age)
+	w.Write([]byte(response))
+}

--- a/server/http.go
+++ b/server/http.go
@@ -9,7 +9,6 @@ import (
 func (s *Server) txStatusHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract query parameters
 	txHash := r.URL.Query().Get("hash")
-	fmt.Printf("txHash: %s\n", txHash)
 
 	// Get block from rpc.
 	txInfo, err := s.rpcServer.fg.QueryTransactionStatus(txHash)

--- a/server/server.go
+++ b/server/server.go
@@ -95,7 +95,7 @@ func (s *Server) RunUntilShutdown() error {
 
 	// Create http server.
 	httpServer := &http.Server{
-		Addr:    ":8080",
+		Addr:    s.cfg.HTTPListener,
 		Handler: corsHandler,
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,8 @@ package server
 import (
 	"fmt"
 	"net"
+	"net/http"
+	"net/url"
 	"sync"
 	"sync/atomic"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/babylonlabs-io/finality-gadget/db"
 	"github.com/babylonlabs-io/finality-gadget/finalitygadget"
 	"github.com/lightningnetwork/lnd/signal"
+	"github.com/rs/cors"
 	"go.uber.org/zap"
 
 	"google.golang.org/grpc"
@@ -60,9 +63,9 @@ func (s *Server) RunUntilShutdown() error {
 	}
 	defer lis.Close()
 
+	// Create grpc server
 	grpcServer := grpc.NewServer()
 	defer grpcServer.Stop()
-
 	if err := s.rpcServer.RegisterWithGrpcServer(grpcServer); err != nil {
 		return fmt.Errorf("failed to register gRPC server: %w", err)
 	}
@@ -71,6 +74,34 @@ func (s *Server) RunUntilShutdown() error {
 	// actually start listening for requests.
 	if err := s.startGrpcListen(grpcServer, []net.Listener{lis}); err != nil {
 		return fmt.Errorf("failed to start gRPC listener: %v", err)
+	}
+
+	// Add cors handler to allow local development
+	corsHandler := cors.New(cors.Options{
+		AllowOriginFunc: func(origin string) bool {
+			u, err := url.Parse(origin)
+			if err != nil {
+				return false
+			}
+			if u.Hostname() == "localhost" || u.Hostname() == "127.0.0.1" {
+				return true
+			}
+			return false
+		},
+		AllowCredentials: true,
+		AllowedMethods:   []string{"GET", "POST"},
+		AllowedHeaders:   []string{"Content-Type", "Authorization"},
+	}).Handler(s.newHttpHandler())
+
+	// Create http server.
+	httpServer := &http.Server{
+		Addr:    ":8080",
+		Handler: corsHandler,
+	}
+
+	s.logger.Info("Starting standalone HTTP server on port 8080")
+	if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		s.logger.Error("HTTP server failed", zap.Error(err))
 	}
 
 	s.logger.Info("Finality gadget is active")
@@ -106,4 +137,11 @@ func (s *Server) startGrpcListen(grpcServer *grpc.Server, listeners []net.Listen
 	wg.Wait()
 
 	return nil
+}
+
+func (s *Server) newHttpHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/transaction", s.txStatusHandler)
+	mux.HandleFunc("/health", s.healthHandler)
+	return mux
 }

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -1,0 +1,20 @@
+package types
+
+type TransactionInfo struct {
+	TxHash           string         `json:"txHash"`
+	BlockTimestamp   uint64         `json:"blockTimestamp"`
+	BlockHeight      uint64         `json:"blockHeight"`
+	BlockHash        string         `json:"blockHash"`
+	Status           FinalityStatus `json:"status"`
+	BabylonFinalized bool           `json:"babylonFinalized"`
+}
+
+type FinalityStatus string
+
+const (
+	FinalityStatusPending          FinalityStatus = "pending"
+	FinalityStatusUnsafe           FinalityStatus = "unsafe"
+	FinalityStatusBitcoinFinalized FinalityStatus = "btc finalized"
+	FinalityStatusSafe             FinalityStatus = "safe"
+	FinalityStatusFinalized        FinalityStatus = "finalized"
+)


### PR DESCRIPTION
## Summary

This PR adds a lightweight http server to the finality gadget, which exposes an HTTP listener to allow the [finality explorer](https://github.com/Snapchain/finality-explorer) frontend to query for the Babylon finality status of transactions.

## Test plan

```
make test
```