### PR TITLE
validate tx hash before querying tx status

### DIFF
--- a/finalitygadget/finalitygadget.go
+++ b/finalitygadget/finalitygadget.go
@@ -279,6 +279,11 @@ func (fg *FinalityGadget) GetBlockByHash(hash string) (*types.Block, error) {
 }
 
 func (fg *FinalityGadget) QueryTransactionStatus(txHash string) (*types.TransactionInfo, error) {
+	// Validate the tx hash is a valid EVM tx hash
+	if len(txHash) != 66 || txHash[:2] != "0x" {
+		return nil, fmt.Errorf("invalid EVM transaction hash")
+	}
+
 	// get block info
 	ctx := context.Background()
 	txReceipt, err := fg.l2Client.TransactionReceipt(ctx, txHash)

--- a/finalitygadget/finalitygadget.go
+++ b/finalitygadget/finalitygadget.go
@@ -279,9 +279,8 @@ func (fg *FinalityGadget) GetBlockByHash(hash string) (*types.Block, error) {
 }
 
 func (fg *FinalityGadget) QueryTransactionStatus(txHash string) (*types.TransactionInfo, error) {
-	// Validate the tx hash is a valid EVM tx hash
-	if len(txHash) != 66 || txHash[:2] != "0x" {
-		return nil, fmt.Errorf("invalid EVM transaction hash")
+	if err := validateEVMTxHash(txHash); err != nil {
+		return nil, err
 	}
 
 	// get block info
@@ -553,4 +552,12 @@ func (fg *FinalityGadget) MonitorBtcStakingActivation(ctx context.Context) {
 
 func normalizeBlockHash(hash string) string {
 	return common.HexToHash(hash).Hex()
+}
+
+// validateEVMTxHash checks if the given string is a valid EVM transaction hash
+func validateEVMTxHash(txHash string) error {
+	if len(txHash) != 66 || txHash[:2] != "0x" {
+		return fmt.Errorf("invalid EVM transaction hash")
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

I see logs

```
txHash: 0xasdddd
2024/09/26 11:10:23 http: panic serving 75.36.15.73:60499: runtime error: invalid memory address or nil pointer dereference
goroutine 27384 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1873 +0xb9
panic({0x3c28f00?, 0x6e918e0?})
	/usr/local/go/src/runtime/panic.go:920 +0x270
github.com/babylonlabs-io/finality-gadget/finalitygadget.(*FinalityGadget).QueryTransactionStatus(0xc00237c070, {0xc002082619?, 0x41c9f0e?})
	/go/src/github.com/babylonlabs-io/finality-gadget/finalitygadget/finalitygadget.go:309 +0x98
github.com/babylonlabs-io/finality-gadget/server.(*Server).txStatusHandler(0xc001dee9c0, {0x4b5f1a0, 0xc001c20000}, 0x3?)
	/go/src/github.com/babylonlabs-io/finality-gadget/server/http.go:15 +0xfc
net/http.HandlerFunc.ServeHTTP(0xc0011220f0?, {0x4b5f1a0?, 0xc001c20000?}, 0x46dd25?)
	/usr/local/go/src/net/http/server.go:2141 +0x29
net/http.(*ServeMux).ServeHTTP(0xc00233a9c0?, {0x4b5f1a0, 0xc001c20000}, 0xc001a78700)
	/usr/local/go/src/net/http/server.go:2519 +0x142
github.com/babylonlabs-io/finality-gadget/server.(*Server).RunUntilShutdown.(*Cors).Handler.func3({0x4b5f1a0, 0xc001c20000}, 0xc001a78700)
	/go/pkg/mod/github.com/rs/cors@v1.11.0/cors.go:289 +0x184
net/http.HandlerFunc.ServeHTTP(0x707e380?, {0x4b5f1a0?, 0xc001c20000?}, 0xc001cb1b50?)
	/usr/local/go/src/net/http/server.go:2141 +0x29
net/http.serverHandler.ServeHTTP({0xc0016a5920?}, {0x4b5f1a0?, 0xc001c20000?}, 0x6?)
	/usr/local/go/src/net/http/server.go:2943 +0x8e
net/http.(*conn).serve(0xc001932d80, {0x4b84648, 0xc00237e6c0})
	/usr/local/go/src/net/http/server.go:2014 +0x5f4
created by net/http.(*Server).Serve in goroutine 245
	/usr/local/go/src/net/http/server.go:3091 +0x5cb
```

## Test Plan

`make build`

will compile and e2e test on our demonet