### PR TITLE
chore: remove healthcheck query params

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"go.uber.org/zap"
@@ -35,12 +34,7 @@ func (s *Server) txStatusHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
-	// Extract query parameters
-	name := r.URL.Query().Get("name")
-	age := r.URL.Query().Get("age")
-
-	// Respond with the parameters
-	response := fmt.Sprintf("Name: %s, Age: %s", name, age)
+	response := "Finality gadget is healthy"
 	_, err := w.Write([]byte(response))
 	if err != nil {
 		s.logger.Error("Failed to write response", zap.Error(err))


### PR DESCRIPTION
## Summary

This is a small PR to remove old boilerplate query params under the `/health` healthcheck route. 

## Test plan

```
make build
make test
```