### PR TITLE
feat: query latest block info

### DIFF
--- a/db/bbolt.go
+++ b/db/bbolt.go
@@ -23,7 +23,8 @@ var _ IDatabaseHandler = &BBoltHandler{}
 const (
 	blocksBucket          = "blocks"
 	blockHeightsBucket    = "block_heights"
-	latestBlockBucket     = "latest_block"
+	indexerBucket         = "indexer"
+	earliestBlockKey      = "earliest"
 	latestBlockKey        = "latest"
 	activatedTimestampKey = "activated_timestamp"
 )
@@ -53,7 +54,7 @@ func NewBBoltHandler(path string, logger *zap.Logger) (*BBoltHandler, error) {
 func (bb *BBoltHandler) CreateInitialSchema() error {
 	bb.logger.Info("Initialising DB...")
 	return bb.db.Update(func(tx *bolt.Tx) error {
-		buckets := []string{blocksBucket, blockHeightsBucket, latestBlockBucket}
+		buckets := []string{blocksBucket, blockHeightsBucket, indexerBucket}
 		for _, bucket := range buckets {
 			if err := bb.tryCreateBucket(tx, bucket); err != nil {
 				return err
@@ -91,6 +92,24 @@ func (bb *BBoltHandler) InsertBlock(block *types.Block) error {
 		return err
 	}
 
+	// Get current earliest block
+	// If it is unset, update earliest block
+	earliestBlock, err := bb.QueryEarliestFinalizedBlock()
+	if earliestBlock == nil || errors.Is(err, types.ErrBlockNotFound) {
+		err = bb.db.Update(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte(indexerBucket))
+			return b.Put([]byte(earliestBlockKey), bb.itob(block.BlockHeight))
+		})
+		if err != nil {
+			bb.logger.Error("Error updating earliest block", zap.Error(err))
+			return err
+		}
+	}
+	if err != nil {
+		bb.logger.Error("Error getting earliest block", zap.Error(err))
+		return err
+	}
+
 	// Get current latest block
 	latestBlock, err := bb.QueryLatestFinalizedBlock()
 	if latestBlock == nil {
@@ -103,7 +122,7 @@ func (bb *BBoltHandler) InsertBlock(block *types.Block) error {
 
 	// Update latest block if it's the latest
 	err = bb.db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte(latestBlockBucket))
+		b := tx.Bucket([]byte(indexerBucket))
 		if err != nil {
 			bb.logger.Error("Error getting latest block", zap.Error(err))
 			return err
@@ -188,60 +207,21 @@ func (bb *BBoltHandler) QueryIsBlockFinalizedByHash(hash string) (bool, error) {
 	return bb.QueryIsBlockFinalizedByHeight(blockHeight)
 }
 
-func (bb *BBoltHandler) QueryEarliestConsecutivelyFinalizedBlock() (*types.Block, error) {
-	// Get the latest finalized block
-	latestBlock, err := bb.QueryLatestFinalizedBlock()
-	if err != nil {
-		return nil, err
-	}
-	latestBlockHeight := latestBlock.BlockHeight
-
-	var earliestConsecutiveBlock *types.Block
-
-	// Use a cursor to efficiently scan the blocks bucket backwards
-	err = bb.db.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte(blocksBucket))
-		if b == nil {
-			return errors.New("blocks bucket not found")
-		}
-
-		c := b.Cursor()
-
-		// Start by seeking to the latest block height
-		seekKey := bb.itob(latestBlockHeight)
-		k, _ := c.Seek(seekKey)
-		if k == nil {
+func (bb *BBoltHandler) QueryEarliestFinalizedBlock() (*types.Block, error) {
+	var earliestBlockHeight uint64
+	err := bb.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(indexerBucket))
+		v := b.Get([]byte(earliestBlockKey))
+		if v == nil {
 			return types.ErrBlockNotFound
 		}
-
-		// Iterate backwards to find the earliest consecutive block
-		expectedHeight := latestBlockHeight
-		for k, v := c.Last(); k != nil; k, v = c.Prev() {
-			blockHeight := bb.btoi(k)
-
-			// If the block height is not consecutive, stop
-			if blockHeight != expectedHeight {
-				break
-			}
-
-			// Unmarshal the block data
-			var block types.Block
-			if err := json.Unmarshal(v, &block); err != nil {
-				return err
-			}
-			earliestConsecutiveBlock = &block
-
-			// Decrease the expected height for the next iteration
-			expectedHeight--
-		}
-
+		earliestBlockHeight = bb.btoi(v)
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-
-	return earliestConsecutiveBlock, nil
+	return bb.GetBlockByHeight(earliestBlockHeight)
 }
 
 func (bb *BBoltHandler) QueryLatestFinalizedBlock() (*types.Block, error) {
@@ -249,7 +229,7 @@ func (bb *BBoltHandler) QueryLatestFinalizedBlock() (*types.Block, error) {
 
 	// Fetch latest block height
 	err := bb.db.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte(latestBlockBucket))
+		b := tx.Bucket([]byte(indexerBucket))
 		v := b.Get([]byte(latestBlockKey))
 		if v == nil {
 			return types.ErrBlockNotFound
@@ -273,7 +253,7 @@ func (bb *BBoltHandler) QueryLatestFinalizedBlock() (*types.Block, error) {
 func (bb *BBoltHandler) GetActivatedTimestamp() (uint64, error) {
 	var timestamp uint64
 	err := bb.db.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte(latestBlockBucket))
+		b := tx.Bucket([]byte(indexerBucket))
 		v := b.Get([]byte(activatedTimestampKey))
 		if v == nil {
 			return types.ErrActivatedTimestampNotFound
@@ -289,7 +269,7 @@ func (bb *BBoltHandler) GetActivatedTimestamp() (uint64, error) {
 
 func (bb *BBoltHandler) SaveActivatedTimestamp(timestamp uint64) error {
 	return bb.db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte(latestBlockBucket))
+		b := tx.Bucket([]byte(indexerBucket))
 		return b.Put([]byte(activatedTimestampKey), bb.itob(timestamp))
 	})
 }

--- a/db/bbolt_test.go
+++ b/db/bbolt_test.go
@@ -185,7 +185,7 @@ func TestQueryIsBlockFinalizedByHashForNonExistentBlock(t *testing.T) {
 	assert.Equal(t, isFinalized, false)
 }
 
-func TestQueryEarliestConsecutivelyFinalizedBlock(t *testing.T) {
+func TestQueryEarliestFinalizedBlock(t *testing.T) {
 	handler, cleanup := setupDB(t)
 	defer cleanup()
 
@@ -195,36 +195,29 @@ func TestQueryEarliestConsecutivelyFinalizedBlock(t *testing.T) {
 		BlockHash:      "0x123",
 		BlockTimestamp: 1000,
 	}
-	third := &types.Block{
-		BlockHeight:    3,
+	second := &types.Block{
+		BlockHeight:    2,
 		BlockHash:      "0x456",
 		BlockTimestamp: 1050,
 	}
-	fourth := &types.Block{
-		BlockHeight:    4,
+	third := &types.Block{
+		BlockHeight:    3,
 		BlockHash:      "0x789",
 		BlockTimestamp: 1100,
 	}
-	fifth := &types.Block{
-		BlockHeight:    5,
-		BlockHash:      "0xabc",
-		BlockTimestamp: 1150,
-	}
 	err := handler.InsertBlock(first)
+	assert.NoError(t, err)
+	err = handler.InsertBlock(second)
 	assert.NoError(t, err)
 	err = handler.InsertBlock(third)
 	assert.NoError(t, err)
-	err = handler.InsertBlock(fourth)
-	assert.NoError(t, err)
-	err = handler.InsertBlock(fifth)
-	assert.NoError(t, err)
 
 	// Query earliest consecutively finalized block
-	earliestBlock, err := handler.QueryEarliestConsecutivelyFinalizedBlock()
+	earliestBlock, err := handler.QueryEarliestFinalizedBlock()
 	assert.NoError(t, err)
-	assert.Equal(t, earliestBlock.BlockHeight, third.BlockHeight)
-	assert.Equal(t, earliestBlock.BlockHash, third.BlockHash)
-	assert.Equal(t, earliestBlock.BlockTimestamp, third.BlockTimestamp)
+	assert.Equal(t, earliestBlock.BlockHeight, first.BlockHeight)
+	assert.Equal(t, earliestBlock.BlockHash, first.BlockHash)
+	assert.Equal(t, earliestBlock.BlockTimestamp, first.BlockTimestamp)
 }
 
 func TestQueryLatestFinalizedBlock(t *testing.T) {

--- a/db/bbolt_test.go
+++ b/db/bbolt_test.go
@@ -185,6 +185,48 @@ func TestQueryIsBlockFinalizedByHashForNonExistentBlock(t *testing.T) {
 	assert.Equal(t, isFinalized, false)
 }
 
+func TestQueryEarliestConsecutivelyFinalizedBlock(t *testing.T) {
+	handler, cleanup := setupDB(t)
+	defer cleanup()
+
+	// Insert two blocks
+	first := &types.Block{
+		BlockHeight:    1,
+		BlockHash:      "0x123",
+		BlockTimestamp: 1000,
+	}
+	third := &types.Block{
+		BlockHeight:    3,
+		BlockHash:      "0x456",
+		BlockTimestamp: 1050,
+	}
+	fourth := &types.Block{
+		BlockHeight:    4,
+		BlockHash:      "0x789",
+		BlockTimestamp: 1100,
+	}
+	fifth := &types.Block{
+		BlockHeight:    5,
+		BlockHash:      "0xabc",
+		BlockTimestamp: 1150,
+	}
+	err := handler.InsertBlock(first)
+	assert.NoError(t, err)
+	err = handler.InsertBlock(third)
+	assert.NoError(t, err)
+	err = handler.InsertBlock(fourth)
+	assert.NoError(t, err)
+	err = handler.InsertBlock(fifth)
+	assert.NoError(t, err)
+
+	// Query earliest consecutively finalized block
+	earliestBlock, err := handler.QueryEarliestConsecutivelyFinalizedBlock()
+	assert.NoError(t, err)
+	assert.Equal(t, earliestBlock.BlockHeight, third.BlockHeight)
+	assert.Equal(t, earliestBlock.BlockHash, third.BlockHash)
+	assert.Equal(t, earliestBlock.BlockTimestamp, third.BlockTimestamp)
+}
+
 func TestQueryLatestFinalizedBlock(t *testing.T) {
 	handler, cleanup := setupDB(t)
 	defer cleanup()

--- a/db/interface.go
+++ b/db/interface.go
@@ -9,6 +9,7 @@ type IDatabaseHandler interface {
 	GetBlockByHash(hash string) (*types.Block, error)
 	QueryIsBlockFinalizedByHeight(height uint64) (bool, error)
 	QueryIsBlockFinalizedByHash(hash string) (bool, error)
+	QueryEarliestConsecutivelyFinalizedBlock() (*types.Block, error)
 	QueryLatestFinalizedBlock() (*types.Block, error)
 	GetActivatedTimestamp() (uint64, error)
 	SaveActivatedTimestamp(timestamp uint64) error

--- a/db/interface.go
+++ b/db/interface.go
@@ -9,7 +9,7 @@ type IDatabaseHandler interface {
 	GetBlockByHash(hash string) (*types.Block, error)
 	QueryIsBlockFinalizedByHeight(height uint64) (bool, error)
 	QueryIsBlockFinalizedByHash(hash string) (bool, error)
-	QueryEarliestConsecutivelyFinalizedBlock() (*types.Block, error)
+	QueryEarliestFinalizedBlock() (*types.Block, error)
 	QueryLatestFinalizedBlock() (*types.Block, error)
 	GetActivatedTimestamp() (uint64, error)
 	SaveActivatedTimestamp(timestamp uint64) error

--- a/finalitygadget/finalitygadget.go
+++ b/finalitygadget/finalitygadget.go
@@ -338,7 +338,7 @@ func (fg *FinalityGadget) QueryTransactionStatus(txHash string) (*types.Transact
 	}, nil
 }
 
-func (fg *FinalityGadget) QueryLatestBlockInfo() (*types.LatestBlockInfo, error) {
+func (fg *FinalityGadget) QueryChainSyncStatus() (*types.ChainSyncStatus, error) {
 	// Query latest block number
 	ctx := context.Background()
 	latestBlock, err := fg.l2Client.HeaderByNumber(ctx, big.NewInt(ethrpc.LatestBlockNumber.Int64()))
@@ -364,7 +364,7 @@ func (fg *FinalityGadget) QueryLatestBlockInfo() (*types.LatestBlockInfo, error)
 		return nil, err
 	}
 
-	return &types.LatestBlockInfo{
+	return &types.ChainSyncStatus{
 		LatestBlockHeight:               latestBlock.Number.Uint64(),
 		LatestBtcFinalizedBlockHeight:   latestBtcFinalizedBlock.BlockHeight,
 		EarliestBtcFinalizedBlockHeight: earliestBtcFinalizedBlock.BlockHeight,

--- a/finalitygadget/finalitygadget.go
+++ b/finalitygadget/finalitygadget.go
@@ -353,7 +353,7 @@ func (fg *FinalityGadget) QueryChainSyncStatus() (*types.ChainSyncStatus, error)
 	}
 
 	// Query earliest btc finalized block number
-	earliestBtcFinalizedBlock, err := fg.db.QueryEarliestConsecutivelyFinalizedBlock()
+	earliestBtcFinalizedBlock, err := fg.db.QueryEarliestFinalizedBlock()
 	if err != nil {
 		return nil, err
 	}

--- a/finalitygadget/interface.go
+++ b/finalitygadget/interface.go
@@ -75,4 +75,7 @@ type IFinalityGadget interface {
 
 	// QueryTransactionStatus returns the finality status of a transaction
 	QueryTransactionStatus(txHash string) (*types.TransactionInfo, error)
+
+	// QueryLatestBlockInfo returns the latest finalized blocks for display by the finality explorer
+	QueryLatestBlockInfo() (*types.LatestBlockInfo, error)
 }

--- a/finalitygadget/interface.go
+++ b/finalitygadget/interface.go
@@ -76,6 +76,6 @@ type IFinalityGadget interface {
 	// QueryTransactionStatus returns the finality status of a transaction
 	QueryTransactionStatus(txHash string) (*types.TransactionInfo, error)
 
-	// QueryLatestBlockInfo returns the latest finalized blocks for display by the finality explorer
-	QueryLatestBlockInfo() (*types.LatestBlockInfo, error)
+	// QueryChainSyncStatus returns the latest finalized blocks for display by the finality explorer
+	QueryChainSyncStatus() (*types.ChainSyncStatus, error)
 }

--- a/server/http.go
+++ b/server/http.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"go.uber.org/zap"
@@ -35,12 +34,7 @@ func (s *Server) txStatusHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
-	// Extract query parameters
-	name := r.URL.Query().Get("name")
-	age := r.URL.Query().Get("age")
-
-	// Respond with the parameters
-	response := fmt.Sprintf("Name: %s, Age: %s", name, age)
+	response := "Finality gadget is healthy"
 	_, err := w.Write([]byte(response))
 	if err != nil {
 		s.logger.Error("Failed to write response", zap.Error(err))

--- a/server/http.go
+++ b/server/http.go
@@ -33,6 +33,28 @@ func (s *Server) txStatusHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (s *Server) latestBlockInfoHandler(w http.ResponseWriter, r *http.Request) {
+	// Get block from rpc.
+	latestBlockInfo, err := s.rpcServer.fg.QueryLatestBlockInfo()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	jsonResponse, err := json.Marshal(latestBlockInfo)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(jsonResponse)
+	if err != nil {
+		s.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
 func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 	response := "Finality gadget is healthy"
 	_, err := w.Write([]byte(response))

--- a/server/http.go
+++ b/server/http.go
@@ -33,15 +33,15 @@ func (s *Server) txStatusHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) latestBlockInfoHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) chainSyncStatusHandler(w http.ResponseWriter, r *http.Request) {
 	// Get block from rpc.
-	latestBlockInfo, err := s.rpcServer.fg.QueryLatestBlockInfo()
+	chainSyncStatus, err := s.rpcServer.fg.QueryChainSyncStatus()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	jsonResponse, err := json.Marshal(latestBlockInfo)
+	jsonResponse, err := json.Marshal(chainSyncStatus)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -131,7 +131,7 @@ func (s *Server) startGrpcListen(grpcServer *grpc.Server, listeners []net.Listen
 func (s *Server) newHttpHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/transaction", s.txStatusHandler)
-	mux.HandleFunc("/v1/latestBlockInfo", s.latestBlockInfoHandler)
+	mux.HandleFunc("/v1/chainSyncStatus", s.chainSyncStatusHandler)
 	mux.HandleFunc("/health", s.healthHandler)
 	return mux
 }

--- a/server/server.go
+++ b/server/server.go
@@ -131,6 +131,7 @@ func (s *Server) startGrpcListen(grpcServer *grpc.Server, listeners []net.Listen
 func (s *Server) newHttpHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/transaction", s.txStatusHandler)
+	mux.HandleFunc("/v1/latestBlockInfo", s.latestBlockInfoHandler)
 	mux.HandleFunc("/health", s.healthHandler)
 	return mux
 }

--- a/testutil/mocks/db_mock.go
+++ b/testutil/mocks/db_mock.go
@@ -126,19 +126,19 @@ func (mr *MockIDatabaseHandlerMockRecorder) InsertBlock(block any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertBlock", reflect.TypeOf((*MockIDatabaseHandler)(nil).InsertBlock), block)
 }
 
-// QueryEarliestConsecutivelyFinalizedBlock mocks base method.
-func (m *MockIDatabaseHandler) QueryEarliestConsecutivelyFinalizedBlock() (*types.Block, error) {
+// QueryEarliestFinalizedBlock mocks base method.
+func (m *MockIDatabaseHandler) QueryEarliestFinalizedBlock() (*types.Block, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryEarliestConsecutivelyFinalizedBlock")
+	ret := m.ctrl.Call(m, "QueryEarliestFinalizedBlock")
 	ret0, _ := ret[0].(*types.Block)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// QueryEarliestConsecutivelyFinalizedBlock indicates an expected call of QueryEarliestConsecutivelyFinalizedBlock.
-func (mr *MockIDatabaseHandlerMockRecorder) QueryEarliestConsecutivelyFinalizedBlock() *gomock.Call {
+// QueryEarliestFinalizedBlock indicates an expected call of QueryEarliestFinalizedBlock.
+func (mr *MockIDatabaseHandlerMockRecorder) QueryEarliestFinalizedBlock() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryEarliestConsecutivelyFinalizedBlock", reflect.TypeOf((*MockIDatabaseHandler)(nil).QueryEarliestConsecutivelyFinalizedBlock))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryEarliestFinalizedBlock", reflect.TypeOf((*MockIDatabaseHandler)(nil).QueryEarliestFinalizedBlock))
 }
 
 // QueryIsBlockFinalizedByHash mocks base method.

--- a/testutil/mocks/db_mock.go
+++ b/testutil/mocks/db_mock.go
@@ -126,6 +126,21 @@ func (mr *MockIDatabaseHandlerMockRecorder) InsertBlock(block any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertBlock", reflect.TypeOf((*MockIDatabaseHandler)(nil).InsertBlock), block)
 }
 
+// QueryEarliestConsecutivelyFinalizedBlock mocks base method.
+func (m *MockIDatabaseHandler) QueryEarliestConsecutivelyFinalizedBlock() (*types.Block, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryEarliestConsecutivelyFinalizedBlock")
+	ret0, _ := ret[0].(*types.Block)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryEarliestConsecutivelyFinalizedBlock indicates an expected call of QueryEarliestConsecutivelyFinalizedBlock.
+func (mr *MockIDatabaseHandlerMockRecorder) QueryEarliestConsecutivelyFinalizedBlock() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryEarliestConsecutivelyFinalizedBlock", reflect.TypeOf((*MockIDatabaseHandler)(nil).QueryEarliestConsecutivelyFinalizedBlock))
+}
+
 // QueryIsBlockFinalizedByHash mocks base method.
 func (m *MockIDatabaseHandler) QueryIsBlockFinalizedByHash(hash string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/testutil/mocks/expected_clients_mock.go
+++ b/testutil/mocks/expected_clients_mock.go
@@ -319,3 +319,18 @@ func (mr *MockIEthL2ClientMockRecorder) HeaderByNumber(ctx, number any) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeaderByNumber", reflect.TypeOf((*MockIEthL2Client)(nil).HeaderByNumber), ctx, number)
 }
+
+// TransactionReceipt mocks base method.
+func (m *MockIEthL2Client) TransactionReceipt(ctx context.Context, txHash string) (*types0.Receipt, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransactionReceipt", ctx, txHash)
+	ret0, _ := ret[0].(*types0.Receipt)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TransactionReceipt indicates an expected call of TransactionReceipt.
+func (mr *MockIEthL2ClientMockRecorder) TransactionReceipt(ctx, txHash any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionReceipt", reflect.TypeOf((*MockIEthL2Client)(nil).TransactionReceipt), ctx, txHash)
+}

--- a/types/block.go
+++ b/types/block.go
@@ -6,7 +6,7 @@ type Block struct {
 	BlockTimestamp uint64 `json:"block_timestamp" description:"block timestamp"`
 }
 
-type LatestBlockInfo struct {
+type ChainSyncStatus struct {
 	LatestBlockHeight               uint64 `json:"latest_block"`
 	LatestBtcFinalizedBlockHeight   uint64 `json:"latest_btc_finalized_block"`
 	EarliestBtcFinalizedBlockHeight uint64 `json:"earliest_btc_finalized_block"`

--- a/types/block.go
+++ b/types/block.go
@@ -5,3 +5,10 @@ type Block struct {
 	BlockHeight    uint64 `json:"block_height" description:"block height"`
 	BlockTimestamp uint64 `json:"block_timestamp" description:"block timestamp"`
 }
+
+type LatestBlockInfo struct {
+	LatestBlockHeight               uint64 `json:"latest_block"`
+	LatestBtcFinalizedBlockHeight   uint64 `json:"latest_btc_finalized_block"`
+	EarliestBtcFinalizedBlockHeight uint64 `json:"earliest_btc_finalized_block"`
+	LatestEthFinalizedBlockHeight   uint64 `json:"latest_eth_finalized_block"`
+}


### PR DESCRIPTION
## Summary

This stacked PR (following #30) adds a new HTTP api route to return the latest block info, including:

- Latest L2 block
- Latest BTC finalized L2 block
- Earliest consecutively BTC finalized L2 Block
- Latest ETH finalized L2 block

to be displayed by the [finality explorer](https://github.com/Snapchain/finality-explorer/) 

## Test plan

```
make build
make test
``` 