### PR TITLE
chore: set up CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'chore/ci-publish-docker'
+      - 'main'
     tags:
       - '*'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: docker_publish
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - '*'
+
+jobs:
+  lint_test:
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.7.0
+    with:
+      run-build: true
+      run-lint: true
+      run-unit-tests: true
+      run-integration-tests: false
+      run-check-mock-gen: true
+      run-gosec: true
+      gosec-args: "-exclude-generated -exclude-dir=testutil ./..."
+
+  docker_pipeline:
+    needs: ["lint_test"]
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0
+    secrets: inherit
+    with:
+      publish: true
+      repoName: finality-gadget

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,8 @@ jobs:
       run-build: true
       run-lint: true
       run-unit-tests: true
-      run-integration-tests: false
       run-check-mock-gen: true
-      run-gosec: true
+      run-gosec: false
       gosec-args: "-exclude-generated -exclude-dir=testutil ./..."
 
   docker_pipeline:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: docker_publish
 on:
   push:
     branches:
-      - 'main'
+      - 'chore/ci-publish-docker'
     tags:
       - '*'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,8 @@ jobs:
       run-lint: true
       run-unit-tests: true
       run-check-mock-gen: true
-      run-gosec: false
-      gosec-args: "-exclude-generated -exclude-dir=testutil ./..."
+      run-gosec: true
+      gosec-args: "-exclude=G115,G112,G104 -exclude-generated -exclude-dir=testutil ./..."
 
   docker_pipeline:
     needs: ["lint_test"]

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,9 @@ BUILD_ARGS := $(BUILD_ARGS) -o $(BUILDDIR)
 DOCKER ?= $(shell which docker)
 GIT_ROOT := $(shell git rev-parse --show-toplevel)
 
+# https://github.com/babylonlabs-io/finality-gadget/issues/28
 mock-gen:
-	go install go.uber.org/mock/mockgen@latest
+	@which mockgen > /dev/null || CGO_ENABLED=0 go install go.uber.org/mock/mockgen@latest
 	mockgen -source=db/interface.go -package mocks -destination $(MOCKS_DIR)/db_mock.go
 	mockgen -source=finalitygadget/expected_clients.go -package mocks -destination $(MOCKS_DIR)/expected_clients_mock.go
 


### PR DESCRIPTION
## Summary

1. enable build, lint, test, mock-gen
2. build docker and publish to ECR and Docker Hub (only start if `lint_test` job succeeded)

used [babylon's reusable workflow](https://github.com/babylonlabs-io/.github) that's referenced [here](https://github.com/babylonlabs-io/finality-provider/blob/80f6eb0b83b65efefa8393a5f6561d5aefe3c4cf/.github/workflows/publish.yml#L10) in FP repo

## Test Plan

https://github.com/babylonlabs-io/finality-gadget/pull/32/commits/6e826995e5a9f36fb457318e495f71f7549b87e0 to trigger CI

check the created image on docker hub

![image](https://github.com/user-attachments/assets/832bfb4a-362a-469a-8591-f213409fd4de)
