### PR TITLE
fix: batch process bug

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - 'chore/ci-publish-docker'
       - 'main'
-      # TODO: delete temp branch after merging with main
-      - 'fix/batch-process-bug'
     tags:
       - '*'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - 'chore/ci-publish-docker'
       - 'main'
+      # TODO: delete temp branch after merging with main
+      - 'fix/batch-process-bug'
     tags:
       - '*'
 

--- a/btcclient/btcclient_test.go
+++ b/btcclient/btcclient_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/babylonlabs-io/finality-gadget/log"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 )
 
 // TODO: 1) not rely on mainnet RPC; 2) add more tests for some other edge cases
@@ -14,7 +15,7 @@ func TestBtcClient(t *testing.T) {
 	var err error
 
 	// Create logger.
-	logger, err := log.NewRootLogger("console", true)
+	logger, err := log.NewRootLogger("console", zapcore.DebugLevel)
 	require.Nil(t, err)
 
 	// Create BTC client

--- a/cmd/opfgd/start.go
+++ b/cmd/opfgd/start.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/babylonlabs-io/finality-gadget/config"
 	"github.com/babylonlabs-io/finality-gadget/db"
@@ -45,7 +46,11 @@ func runStartCmd(ctx client.Context, cmd *cobra.Command, args []string) error {
 	}
 
 	// Create logger
-	logger, err := log.NewRootLogger("console", cfg.DebugLogLevel)
+	logLevel, err := zapcore.ParseLevel(cfg.LogLevel)
+	if err != nil {
+		return fmt.Errorf("invalid log level: %w", err)
+	}
+	logger, err := log.NewRootLogger("console", logLevel)
 	if err != nil {
 		return fmt.Errorf("failed to create logger: %w", err)
 	}

--- a/cmd/opfgd/start.go
+++ b/cmd/opfgd/start.go
@@ -45,7 +45,7 @@ func runStartCmd(ctx client.Context, cmd *cobra.Command, args []string) error {
 	}
 
 	// Create logger
-	logger, err := log.NewRootLogger("console", true)
+	logger, err := log.NewRootLogger("console", cfg.DebugLogLevel)
 	if err != nil {
 		return fmt.Errorf("failed to create logger: %w", err)
 	}

--- a/config.toml.example
+++ b/config.toml.example
@@ -11,3 +11,4 @@ GRPCListener = "0.0.0.0:50051"
 HTTPListener = "0.0.0.0:8080"
 PollInterval = "10s"
 BatchSize = 10
+DebugLogLevel = false

--- a/config.toml.example
+++ b/config.toml.example
@@ -11,4 +11,4 @@ GRPCListener = "0.0.0.0:50051"
 HTTPListener = "0.0.0.0:8080"
 PollInterval = "10s"
 BatchSize = 10
-DebugLogLevel = false
+LogLevel = "info"

--- a/config/config.go
+++ b/config/config.go
@@ -19,9 +19,9 @@ type Config struct {
 	GRPCListener      string        `long:"grpc-listener" description:"host:port to listen for gRPC connections"`
 	HTTPListener      string        `long:"http-listener" description:"host:port to listen for HTTP connections"`
 	BitcoinDisableTLS bool          `long:"bitcoin-disable-tls" description:"disable TLS for RPC connections"`
-	DebugLogLevel     bool          `long:"debug-log-level" description:"set log level to debug (true) or info (false)"`
 	PollInterval      time.Duration `long:"retry-interval" description:"interval in seconds to recheck Babylon finality of block"`
 	BatchSize         uint64        `long:"batch-size" description:"number of blocks to process in a batch"`
+	LogLevel          string        `long:"log-level" description:"log level (debug, info, warn, error)"`
 }
 
 func (c *Config) Validate() error {
@@ -79,6 +79,11 @@ func Load(configPath string) (*Config, error) {
 
 	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	// set log level
+	if config.LogLevel == "" {
+		config.LogLevel = "info"
 	}
 
 	return &config, nil

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	BitcoinDisableTLS bool          `long:"bitcoin-disable-tls" description:"disable TLS for RPC connections"`
 	PollInterval      time.Duration `long:"retry-interval" description:"interval in seconds to recheck Babylon finality of block"`
 	BatchSize         uint64        `long:"batch-size" description:"number of blocks to process in a batch"`
+	DebugLogLevel     bool          `long:"debug-log-level" description:"set log level to debug (true) or info (false)"`
 }
 
 func (c *Config) Validate() error {

--- a/config/config.go
+++ b/config/config.go
@@ -19,9 +19,9 @@ type Config struct {
 	GRPCListener      string        `long:"grpc-listener" description:"host:port to listen for gRPC connections"`
 	HTTPListener      string        `long:"http-listener" description:"host:port to listen for HTTP connections"`
 	BitcoinDisableTLS bool          `long:"bitcoin-disable-tls" description:"disable TLS for RPC connections"`
+	DebugLogLevel     bool          `long:"debug-log-level" description:"set log level to debug (true) or info (false)"`
 	PollInterval      time.Duration `long:"retry-interval" description:"interval in seconds to recheck Babylon finality of block"`
 	BatchSize         uint64        `long:"batch-size" description:"number of blocks to process in a batch"`
-	DebugLogLevel     bool          `long:"debug-log-level" description:"set log level to debug (true) or info (false)"`
 }
 
 func (c *Config) Validate() error {

--- a/config/config.go
+++ b/config/config.go
@@ -18,10 +18,10 @@ type Config struct {
 	DBFilePath        string        `long:"db-file-path" description:"path to the DB file"`
 	GRPCListener      string        `long:"grpc-listener" description:"host:port to listen for gRPC connections"`
 	HTTPListener      string        `long:"http-listener" description:"host:port to listen for HTTP connections"`
+	LogLevel          string        `long:"log-level" description:"log level (debug, info, warn, error)"`
 	BitcoinDisableTLS bool          `long:"bitcoin-disable-tls" description:"disable TLS for RPC connections"`
 	PollInterval      time.Duration `long:"retry-interval" description:"interval in seconds to recheck Babylon finality of block"`
 	BatchSize         uint64        `long:"batch-size" description:"number of blocks to process in a batch"`
-	LogLevel          string        `long:"log-level" description:"log level (debug, info, warn, error)"`
 }
 
 func (c *Config) Validate() error {
@@ -81,7 +81,7 @@ func Load(configPath string) (*Config, error) {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 
-	// set log level
+	// set default log level
 	if config.LogLevel == "" {
 		config.LogLevel = "info"
 	}

--- a/db/bbolt_test.go
+++ b/db/bbolt_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/babylonlabs-io/finality-gadget/log"
 	"github.com/babylonlabs-io/finality-gadget/types"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 func setupDB(t *testing.T) (*BBoltHandler, func()) {
@@ -19,7 +20,7 @@ func setupDB(t *testing.T) (*BBoltHandler, func()) {
 	tempFile.Close()
 
 	// Create logger.
-	logger, err := log.NewRootLogger("console", true)
+	logger, err := log.NewRootLogger("console", zap.DebugLevel)
 	if err != nil {
 		t.Fatalf("Failed to create logger: %v", err)
 	}

--- a/finalitygadget/finalitygadget.go
+++ b/finalitygadget/finalitygadget.go
@@ -495,7 +495,7 @@ func (fg *FinalityGadget) Startup(ctx context.Context) error {
 				return fmt.Errorf("error fetching latest finalized block from db: %w", err)
 			}
 			fg.lastProcessedHeight = latestFinalizedHeight - 1
-			if latestFinalizedBlockDb.BlockHeight > latestFinalizedHeight {
+			if latestFinalizedBlockDb != nil && latestFinalizedBlockDb.BlockHeight > latestFinalizedHeight {
 				fg.lastProcessedHeight = latestFinalizedBlockDb.BlockHeight
 			}
 			fg.logger.Info("Starting finality gadget from block", zap.Uint64("block_height", fg.lastProcessedHeight+1))

--- a/log/log.go
+++ b/log/log.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func NewRootLogger(format string, debug bool) (*zap.Logger, error) {
+func NewRootLogger(format string, logLevel zapcore.Level) (*zap.Logger, error) {
 	cfg := zap.NewProductionEncoderConfig()
 	cfg.EncodeTime = func(ts time.Time, encoder zapcore.PrimitiveArrayEncoder) {
 		encoder.AppendString(ts.UTC().Format("2006-01-02T15:04:05.000000Z07:00"))
@@ -29,13 +29,9 @@ func NewRootLogger(format string, debug bool) (*zap.Logger, error) {
 		return nil, fmt.Errorf("unrecognized log format %q", format)
 	}
 
-	level := zap.InfoLevel
-	if debug {
-		level = zap.DebugLevel
-	}
 	return zap.New(zapcore.NewCore(
 		enc,
 		os.Stderr,
-		level,
+		logLevel,
 	)), nil
 }


### PR DESCRIPTION
## Summary

This PR fixes a bug introduced in the batch processing refactor in https://github.com/babylonlabs-io/finality-gadget/pull/35.

here, we incorrectly assume that the returned `results` channel is ordered by height. since block fetching is now async, this channel is actually unordered and needs to first be sorted. 

https://github.com/babylonlabs-io/finality-gadget/blob/0409cd8a4ae10cbca771e8b4fde7a4fc5b93d4a0/finalitygadget/finalitygadget.go#L623-L632

the impact of this change was that not all finalized blocks were inserted to the db, even though the latest finalized height advances correctly

besides the fix, we also update FG to:
- allow it to recover from local state after crashes / restarts
- add more debugging logs
- add a new env var in `config.toml` to set the log level at runtime

## Test plan

```
make test
```

This bug wasn't caught by previous tests because it doesn't fall under scope of the unit tests (we mock DB inserts to keep the DB implementation generic). It would have been caught by e2e tests, but we deferred this task in favour of testing on the live network.

In the future, we should:

- add e2e test cases to prevent code regression
- add more debugging logs so we can catch bugs more easily in live testing