### PR TITLE
chore: refactor http and grpc servers

### DIFF
--- a/cmd/opfgd/start.go
+++ b/cmd/opfgd/start.go
@@ -84,7 +84,7 @@ func runStartCmd(ctx client.Context, cmd *cobra.Command, args []string) error {
 	// Start monitoring BTC staking activation
 	go fg.MonitorBtcStakingActivation(fgCtx)
 
-	// Start grpc server
+	// Start both grpc and http servers
 	// Hook interceptor for os signals.
 	shutdownInterceptor, err := sig.Intercept()
 	if err != nil {

--- a/server/grpcserver.go
+++ b/server/grpcserver.go
@@ -3,19 +3,9 @@ package server
 import (
 	"context"
 
-	"google.golang.org/grpc"
-
 	"github.com/babylonlabs-io/finality-gadget/proto"
 	"github.com/babylonlabs-io/finality-gadget/types"
 )
-
-// RegisterWithGrpcServer registers the rpcServer with the passed root gRPC
-// server.
-func (s *Server) RegisterWithGrpcServer(grpcServer *grpc.Server) error {
-	// Register the main RPC server.
-	proto.RegisterFinalityGadgetServer(grpcServer, s)
-	return nil
-}
 
 // QueryIsBlockBabylonFinalized is an RPC method that returns the finality status of a block by querying the internal db.
 func (s *Server) QueryIsBlockBabylonFinalized(ctx context.Context, req *proto.QueryIsBlockBabylonFinalizedRequest) (*proto.QueryIsBlockFinalizedResponse, error) {

--- a/server/grpcserver.go
+++ b/server/grpcserver.go
@@ -11,15 +11,15 @@ import (
 
 // RegisterWithGrpcServer registers the rpcServer with the passed root gRPC
 // server.
-func (r *Server) RegisterWithGrpcServer(grpcServer *grpc.Server) error {
+func (s *Server) RegisterWithGrpcServer(grpcServer *grpc.Server) error {
 	// Register the main RPC server.
-	proto.RegisterFinalityGadgetServer(grpcServer, r)
+	proto.RegisterFinalityGadgetServer(grpcServer, s)
 	return nil
 }
 
 // QueryIsBlockBabylonFinalized is an RPC method that returns the finality status of a block by querying the internal db.
-func (r *Server) QueryIsBlockBabylonFinalized(ctx context.Context, req *proto.QueryIsBlockBabylonFinalizedRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
-	isFinalized, err := r.fg.QueryIsBlockBabylonFinalized(&types.Block{
+func (s *Server) QueryIsBlockBabylonFinalized(ctx context.Context, req *proto.QueryIsBlockBabylonFinalizedRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
+	isFinalized, err := s.fg.QueryIsBlockBabylonFinalized(&types.Block{
 		BlockHash:      req.Block.BlockHash,
 		BlockHeight:    req.Block.BlockHeight,
 		BlockTimestamp: req.Block.BlockTimestamp,
@@ -32,8 +32,8 @@ func (r *Server) QueryIsBlockBabylonFinalized(ctx context.Context, req *proto.Qu
 }
 
 // QueryIsBlockBabylonFinalizedFromBabylon is an RPC method that returns the finality status of a block by querying Babylon chain.
-func (r *Server) QueryIsBlockBabylonFinalizedFromBabylon(ctx context.Context, req *proto.QueryIsBlockBabylonFinalizedRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
-	isFinalized, err := r.fg.QueryIsBlockBabylonFinalizedFromBabylon(&types.Block{
+func (s *Server) QueryIsBlockBabylonFinalizedFromBabylon(ctx context.Context, req *proto.QueryIsBlockBabylonFinalizedRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
+	isFinalized, err := s.fg.QueryIsBlockBabylonFinalizedFromBabylon(&types.Block{
 		BlockHash:      req.Block.BlockHash,
 		BlockHeight:    req.Block.BlockHeight,
 		BlockTimestamp: req.Block.BlockTimestamp,
@@ -46,7 +46,7 @@ func (r *Server) QueryIsBlockBabylonFinalizedFromBabylon(ctx context.Context, re
 }
 
 // QueryBlockRangeBabylonFinalized is an RPC method that returns the latest Babylon finalized block in a range by querying Babylon chain.
-func (r *Server) QueryBlockRangeBabylonFinalized(ctx context.Context, req *proto.QueryBlockRangeBabylonFinalizedRequest) (*proto.QueryBlockRangeBabylonFinalizedResponse, error) {
+func (s *Server) QueryBlockRangeBabylonFinalized(ctx context.Context, req *proto.QueryBlockRangeBabylonFinalizedRequest) (*proto.QueryBlockRangeBabylonFinalizedResponse, error) {
 	blocks := make([]*types.Block, 0, len(req.Blocks))
 
 	for _, block := range req.Blocks {
@@ -57,7 +57,7 @@ func (r *Server) QueryBlockRangeBabylonFinalized(ctx context.Context, req *proto
 		})
 	}
 
-	blockHeight, err := r.fg.QueryBlockRangeBabylonFinalized(blocks)
+	blockHeight, err := s.fg.QueryBlockRangeBabylonFinalized(blocks)
 	if err != nil {
 		return nil, err
 	}
@@ -72,8 +72,8 @@ func (r *Server) QueryBlockRangeBabylonFinalized(ctx context.Context, req *proto
 }
 
 // QueryBtcStakingActivatedTimestamp is an RPC method that returns the timestamp when BTC staking was activated.
-func (r *Server) QueryBtcStakingActivatedTimestamp(ctx context.Context, req *proto.QueryBtcStakingActivatedTimestampRequest) (*proto.QueryBtcStakingActivatedTimestampResponse, error) {
-	timestamp, err := r.fg.QueryBtcStakingActivatedTimestamp()
+func (s *Server) QueryBtcStakingActivatedTimestamp(ctx context.Context, req *proto.QueryBtcStakingActivatedTimestampRequest) (*proto.QueryBtcStakingActivatedTimestampResponse, error) {
+	timestamp, err := s.fg.QueryBtcStakingActivatedTimestamp()
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +82,8 @@ func (r *Server) QueryBtcStakingActivatedTimestamp(ctx context.Context, req *pro
 }
 
 // QueryIsBlockFinalizedByHeight is an RPC method that returns the status of a block at a given height.
-func (r *Server) QueryIsBlockFinalizedByHeight(ctx context.Context, req *proto.QueryIsBlockFinalizedByHeightRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
-	isFinalized, err := r.fg.QueryIsBlockFinalizedByHeight(req.BlockHeight)
+func (s *Server) QueryIsBlockFinalizedByHeight(ctx context.Context, req *proto.QueryIsBlockFinalizedByHeightRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
+	isFinalized, err := s.fg.QueryIsBlockFinalizedByHeight(req.BlockHeight)
 
 	if err != nil {
 		return nil, err
@@ -93,8 +93,8 @@ func (r *Server) QueryIsBlockFinalizedByHeight(ctx context.Context, req *proto.Q
 }
 
 // QueryIsBlockFinalizedByHeight is an RPC method that returns the status of a block at a given height.
-func (r *Server) QueryIsBlockFinalizedByHash(ctx context.Context, req *proto.QueryIsBlockFinalizedByHashRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
-	isFinalized, err := r.fg.QueryIsBlockFinalizedByHash(req.BlockHash)
+func (s *Server) QueryIsBlockFinalizedByHash(ctx context.Context, req *proto.QueryIsBlockFinalizedByHashRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
+	isFinalized, err := s.fg.QueryIsBlockFinalizedByHash(req.BlockHash)
 
 	if err != nil {
 		return nil, err
@@ -104,8 +104,8 @@ func (r *Server) QueryIsBlockFinalizedByHash(ctx context.Context, req *proto.Que
 }
 
 // QueryLatestFinalizedBlock is an RPC method that returns the latest consecutively finalized block.
-func (r *Server) QueryLatestFinalizedBlock(ctx context.Context, req *proto.QueryLatestFinalizedBlockRequest) (*proto.QueryBlockResponse, error) {
-	block, err := r.fg.QueryLatestFinalizedBlock()
+func (s *Server) QueryLatestFinalizedBlock(ctx context.Context, req *proto.QueryLatestFinalizedBlockRequest) (*proto.QueryBlockResponse, error) {
+	block, err := s.fg.QueryLatestFinalizedBlock()
 
 	if block == nil {
 		return nil, types.ErrBlockNotFound

--- a/server/grpcserver.go
+++ b/server/grpcserver.go
@@ -12,7 +12,7 @@ import (
 
 // rpcServer is the main RPC server for the finality gadget daemon that handles
 // gRPC incoming requests.
-type rpcServer struct {
+type grpcServer struct {
 	proto.UnimplementedFinalityGadgetServer
 
 	fg finalitygadget.IFinalityGadget
@@ -21,22 +21,22 @@ type rpcServer struct {
 // newRPCServer creates a new RPC sever from the set of input dependencies.
 func newRPCServer(
 	fg finalitygadget.IFinalityGadget,
-) *rpcServer {
-	return &rpcServer{
+) *grpcServer {
+	return &grpcServer{
 		fg: fg,
 	}
 }
 
 // RegisterWithGrpcServer registers the rpcServer with the passed root gRPC
 // server.
-func (r *rpcServer) RegisterWithGrpcServer(grpcServer *grpc.Server) error {
+func (r *grpcServer) RegisterWithGrpcServer(grpcServer *grpc.Server) error {
 	// Register the main RPC server.
 	proto.RegisterFinalityGadgetServer(grpcServer, r)
 	return nil
 }
 
 // QueryIsBlockBabylonFinalized is an RPC method that returns the finality status of a block by querying the internal db.
-func (r *rpcServer) QueryIsBlockBabylonFinalized(ctx context.Context, req *proto.QueryIsBlockBabylonFinalizedRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
+func (r *grpcServer) QueryIsBlockBabylonFinalized(ctx context.Context, req *proto.QueryIsBlockBabylonFinalizedRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
 	isFinalized, err := r.fg.QueryIsBlockBabylonFinalized(&types.Block{
 		BlockHash:      req.Block.BlockHash,
 		BlockHeight:    req.Block.BlockHeight,
@@ -50,7 +50,7 @@ func (r *rpcServer) QueryIsBlockBabylonFinalized(ctx context.Context, req *proto
 }
 
 // QueryIsBlockBabylonFinalizedFromBabylon is an RPC method that returns the finality status of a block by querying Babylon chain.
-func (r *rpcServer) QueryIsBlockBabylonFinalizedFromBabylon(ctx context.Context, req *proto.QueryIsBlockBabylonFinalizedRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
+func (r *grpcServer) QueryIsBlockBabylonFinalizedFromBabylon(ctx context.Context, req *proto.QueryIsBlockBabylonFinalizedRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
 	isFinalized, err := r.fg.QueryIsBlockBabylonFinalizedFromBabylon(&types.Block{
 		BlockHash:      req.Block.BlockHash,
 		BlockHeight:    req.Block.BlockHeight,
@@ -64,7 +64,7 @@ func (r *rpcServer) QueryIsBlockBabylonFinalizedFromBabylon(ctx context.Context,
 }
 
 // QueryBlockRangeBabylonFinalized is an RPC method that returns the latest Babylon finalized block in a range by querying Babylon chain.
-func (r *rpcServer) QueryBlockRangeBabylonFinalized(ctx context.Context, req *proto.QueryBlockRangeBabylonFinalizedRequest) (*proto.QueryBlockRangeBabylonFinalizedResponse, error) {
+func (r *grpcServer) QueryBlockRangeBabylonFinalized(ctx context.Context, req *proto.QueryBlockRangeBabylonFinalizedRequest) (*proto.QueryBlockRangeBabylonFinalizedResponse, error) {
 	blocks := make([]*types.Block, 0, len(req.Blocks))
 
 	for _, block := range req.Blocks {
@@ -90,7 +90,7 @@ func (r *rpcServer) QueryBlockRangeBabylonFinalized(ctx context.Context, req *pr
 }
 
 // QueryBtcStakingActivatedTimestamp is an RPC method that returns the timestamp when BTC staking was activated.
-func (r *rpcServer) QueryBtcStakingActivatedTimestamp(ctx context.Context, req *proto.QueryBtcStakingActivatedTimestampRequest) (*proto.QueryBtcStakingActivatedTimestampResponse, error) {
+func (r *grpcServer) QueryBtcStakingActivatedTimestamp(ctx context.Context, req *proto.QueryBtcStakingActivatedTimestampRequest) (*proto.QueryBtcStakingActivatedTimestampResponse, error) {
 	timestamp, err := r.fg.QueryBtcStakingActivatedTimestamp()
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func (r *rpcServer) QueryBtcStakingActivatedTimestamp(ctx context.Context, req *
 }
 
 // QueryIsBlockFinalizedByHeight is an RPC method that returns the status of a block at a given height.
-func (r *rpcServer) QueryIsBlockFinalizedByHeight(ctx context.Context, req *proto.QueryIsBlockFinalizedByHeightRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
+func (r *grpcServer) QueryIsBlockFinalizedByHeight(ctx context.Context, req *proto.QueryIsBlockFinalizedByHeightRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
 	isFinalized, err := r.fg.QueryIsBlockFinalizedByHeight(req.BlockHeight)
 
 	if err != nil {
@@ -111,7 +111,7 @@ func (r *rpcServer) QueryIsBlockFinalizedByHeight(ctx context.Context, req *prot
 }
 
 // QueryIsBlockFinalizedByHeight is an RPC method that returns the status of a block at a given height.
-func (r *rpcServer) QueryIsBlockFinalizedByHash(ctx context.Context, req *proto.QueryIsBlockFinalizedByHashRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
+func (r *grpcServer) QueryIsBlockFinalizedByHash(ctx context.Context, req *proto.QueryIsBlockFinalizedByHashRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
 	isFinalized, err := r.fg.QueryIsBlockFinalizedByHash(req.BlockHash)
 
 	if err != nil {
@@ -122,7 +122,7 @@ func (r *rpcServer) QueryIsBlockFinalizedByHash(ctx context.Context, req *proto.
 }
 
 // QueryLatestFinalizedBlock is an RPC method that returns the latest consecutively finalized block.
-func (r *rpcServer) QueryLatestFinalizedBlock(ctx context.Context, req *proto.QueryLatestFinalizedBlockRequest) (*proto.QueryBlockResponse, error) {
+func (r *grpcServer) QueryLatestFinalizedBlock(ctx context.Context, req *proto.QueryLatestFinalizedBlockRequest) (*proto.QueryBlockResponse, error) {
 	block, err := r.fg.QueryLatestFinalizedBlock()
 
 	if block == nil {

--- a/server/grpcserver.go
+++ b/server/grpcserver.go
@@ -5,38 +5,20 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/babylonlabs-io/finality-gadget/finalitygadget"
 	"github.com/babylonlabs-io/finality-gadget/proto"
 	"github.com/babylonlabs-io/finality-gadget/types"
 )
 
-// rpcServer is the main RPC server for the finality gadget daemon that handles
-// gRPC incoming requests.
-type grpcServer struct {
-	proto.UnimplementedFinalityGadgetServer
-
-	fg finalitygadget.IFinalityGadget
-}
-
-// newRPCServer creates a new RPC sever from the set of input dependencies.
-func newRPCServer(
-	fg finalitygadget.IFinalityGadget,
-) *grpcServer {
-	return &grpcServer{
-		fg: fg,
-	}
-}
-
 // RegisterWithGrpcServer registers the rpcServer with the passed root gRPC
 // server.
-func (r *grpcServer) RegisterWithGrpcServer(grpcServer *grpc.Server) error {
+func (r *Server) RegisterWithGrpcServer(grpcServer *grpc.Server) error {
 	// Register the main RPC server.
 	proto.RegisterFinalityGadgetServer(grpcServer, r)
 	return nil
 }
 
 // QueryIsBlockBabylonFinalized is an RPC method that returns the finality status of a block by querying the internal db.
-func (r *grpcServer) QueryIsBlockBabylonFinalized(ctx context.Context, req *proto.QueryIsBlockBabylonFinalizedRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
+func (r *Server) QueryIsBlockBabylonFinalized(ctx context.Context, req *proto.QueryIsBlockBabylonFinalizedRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
 	isFinalized, err := r.fg.QueryIsBlockBabylonFinalized(&types.Block{
 		BlockHash:      req.Block.BlockHash,
 		BlockHeight:    req.Block.BlockHeight,
@@ -50,7 +32,7 @@ func (r *grpcServer) QueryIsBlockBabylonFinalized(ctx context.Context, req *prot
 }
 
 // QueryIsBlockBabylonFinalizedFromBabylon is an RPC method that returns the finality status of a block by querying Babylon chain.
-func (r *grpcServer) QueryIsBlockBabylonFinalizedFromBabylon(ctx context.Context, req *proto.QueryIsBlockBabylonFinalizedRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
+func (r *Server) QueryIsBlockBabylonFinalizedFromBabylon(ctx context.Context, req *proto.QueryIsBlockBabylonFinalizedRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
 	isFinalized, err := r.fg.QueryIsBlockBabylonFinalizedFromBabylon(&types.Block{
 		BlockHash:      req.Block.BlockHash,
 		BlockHeight:    req.Block.BlockHeight,
@@ -64,7 +46,7 @@ func (r *grpcServer) QueryIsBlockBabylonFinalizedFromBabylon(ctx context.Context
 }
 
 // QueryBlockRangeBabylonFinalized is an RPC method that returns the latest Babylon finalized block in a range by querying Babylon chain.
-func (r *grpcServer) QueryBlockRangeBabylonFinalized(ctx context.Context, req *proto.QueryBlockRangeBabylonFinalizedRequest) (*proto.QueryBlockRangeBabylonFinalizedResponse, error) {
+func (r *Server) QueryBlockRangeBabylonFinalized(ctx context.Context, req *proto.QueryBlockRangeBabylonFinalizedRequest) (*proto.QueryBlockRangeBabylonFinalizedResponse, error) {
 	blocks := make([]*types.Block, 0, len(req.Blocks))
 
 	for _, block := range req.Blocks {
@@ -90,7 +72,7 @@ func (r *grpcServer) QueryBlockRangeBabylonFinalized(ctx context.Context, req *p
 }
 
 // QueryBtcStakingActivatedTimestamp is an RPC method that returns the timestamp when BTC staking was activated.
-func (r *grpcServer) QueryBtcStakingActivatedTimestamp(ctx context.Context, req *proto.QueryBtcStakingActivatedTimestampRequest) (*proto.QueryBtcStakingActivatedTimestampResponse, error) {
+func (r *Server) QueryBtcStakingActivatedTimestamp(ctx context.Context, req *proto.QueryBtcStakingActivatedTimestampRequest) (*proto.QueryBtcStakingActivatedTimestampResponse, error) {
 	timestamp, err := r.fg.QueryBtcStakingActivatedTimestamp()
 	if err != nil {
 		return nil, err
@@ -100,7 +82,7 @@ func (r *grpcServer) QueryBtcStakingActivatedTimestamp(ctx context.Context, req 
 }
 
 // QueryIsBlockFinalizedByHeight is an RPC method that returns the status of a block at a given height.
-func (r *grpcServer) QueryIsBlockFinalizedByHeight(ctx context.Context, req *proto.QueryIsBlockFinalizedByHeightRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
+func (r *Server) QueryIsBlockFinalizedByHeight(ctx context.Context, req *proto.QueryIsBlockFinalizedByHeightRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
 	isFinalized, err := r.fg.QueryIsBlockFinalizedByHeight(req.BlockHeight)
 
 	if err != nil {
@@ -111,7 +93,7 @@ func (r *grpcServer) QueryIsBlockFinalizedByHeight(ctx context.Context, req *pro
 }
 
 // QueryIsBlockFinalizedByHeight is an RPC method that returns the status of a block at a given height.
-func (r *grpcServer) QueryIsBlockFinalizedByHash(ctx context.Context, req *proto.QueryIsBlockFinalizedByHashRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
+func (r *Server) QueryIsBlockFinalizedByHash(ctx context.Context, req *proto.QueryIsBlockFinalizedByHashRequest) (*proto.QueryIsBlockFinalizedResponse, error) {
 	isFinalized, err := r.fg.QueryIsBlockFinalizedByHash(req.BlockHash)
 
 	if err != nil {
@@ -122,7 +104,7 @@ func (r *grpcServer) QueryIsBlockFinalizedByHash(ctx context.Context, req *proto
 }
 
 // QueryLatestFinalizedBlock is an RPC method that returns the latest consecutively finalized block.
-func (r *grpcServer) QueryLatestFinalizedBlock(ctx context.Context, req *proto.QueryLatestFinalizedBlockRequest) (*proto.QueryBlockResponse, error) {
+func (r *Server) QueryLatestFinalizedBlock(ctx context.Context, req *proto.QueryLatestFinalizedBlockRequest) (*proto.QueryBlockResponse, error) {
 	block, err := r.fg.QueryLatestFinalizedBlock()
 
 	if block == nil {

--- a/server/httpserver.go
+++ b/server/httpserver.go
@@ -7,13 +7,21 @@ import (
 	"go.uber.org/zap"
 )
 
+func (s *Server) newHttpHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/transaction", s.txStatusHandler)
+	mux.HandleFunc("/v1/chainSyncStatus", s.chainSyncStatusHandler)
+	mux.HandleFunc("/health", s.healthHandler)
+	return mux
+}
+
 func (s *Server) txStatusHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract query parameters
 	txHash := r.URL.Query().Get("hash")
 	s.logger.Debug("Received transaction hash", zap.String("txHash", txHash))
 
 	// Get block from rpc.
-	txInfo, err := s.rpcServer.fg.QueryTransactionStatus(txHash)
+	txInfo, err := s.fg.QueryTransactionStatus(txHash)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -35,7 +43,7 @@ func (s *Server) txStatusHandler(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) chainSyncStatusHandler(w http.ResponseWriter, r *http.Request) {
 	// Get block from rpc.
-	chainSyncStatus, err := s.rpcServer.fg.QueryChainSyncStatus()
+	chainSyncStatus, err := s.fg.QueryChainSyncStatus()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/babylonlabs-io/finality-gadget/config"
 	"github.com/babylonlabs-io/finality-gadget/db"
 	"github.com/babylonlabs-io/finality-gadget/finalitygadget"
+	"github.com/babylonlabs-io/finality-gadget/proto"
 	"github.com/lightningnetwork/lnd/signal"
 	"github.com/rs/cors"
 	"go.uber.org/zap"
@@ -22,6 +23,7 @@ import (
 // handles spinning up both the gRPC and HTTP servers, the database, and any
 // other components that the the finality gadget server needs to run.
 type Server struct {
+	proto.UnimplementedFinalityGadgetServer
 	fg  finalitygadget.IFinalityGadget
 	cfg *config.Config
 	db  db.IDatabaseHandler
@@ -86,7 +88,7 @@ func (s *Server) startGrpcServer() error {
 	grpcServer := grpc.NewServer()
 	defer grpcServer.Stop()
 
-	if err := newRPCServer(s.fg).RegisterWithGrpcServer(grpcServer); err != nil {
+	if err := s.RegisterWithGrpcServer(grpcServer); err != nil {
 		return fmt.Errorf("failed to register gRPC server: %w", err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -88,9 +88,7 @@ func (s *Server) startGrpcServer() error {
 	grpcServer := grpc.NewServer()
 	defer grpcServer.Stop()
 
-	if err := s.RegisterWithGrpcServer(grpcServer); err != nil {
-		return fmt.Errorf("failed to register gRPC server: %w", err)
-	}
+	proto.RegisterFinalityGadgetServer(grpcServer, s)
 
 	var wg sync.WaitGroup
 	wg.Add(1)


### PR DESCRIPTION
## Summary

the `Server` struct has a field for grpc server, which contains a `fg` field. The grpc server is used by the http server to access the `fg` field.

the `rpcServer` wrapper class seems unnecessary as well and adds complexity to the code

so I am cleaning up this coupling to make the code more readable

the new `Server` struct just defines the `fg` field, which acts as the service layer where both the http and grpc servers can access it

---

after this refactor, it's much easier to do things like https://github.com/babylonlabs-io/finality-gadget/pull/43


## Test Plan

```
make lint
make test
```

both passed