### PR TITLE
fix: check response before unmarshaling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ name: docker_publish
 on:
   push:
     branches:
-      - 'chore/ci-publish-docker'
       - 'main'
     tags:
       - '*'
@@ -29,37 +28,3 @@ jobs:
     with:
       publish: true
       repoName: finality-gadget
-      
-  test_finality_provider:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Clone finality-provider repository
-        run: |
-          current_hash=$(git rev-parse HEAD)
-          remote_url=$(git remote get-url origin)
-          if [[ $remote_url == https://* ]]; then
-              # For HTTPS URLs
-              repo_path=$(echo $remote_url | sed -E 's|https://github.com/(.+)(\.git)*|\1|')
-          else
-              # For SSH URLs
-              repo_path=$(echo $remote_url | sed -E 's/.*:(.+)\.git/\1/')
-          fi
-          fp_version=$(go list -m github.com/$repo_path@$current_hash)
-
-          git clone https://github.com/babylonlabs-io/finality-provider
-          cd finality-provider
-          git checkout base/consumer-chain-support
-          sed -i "s|github\.com\/babylonlabs-io\/finality-gadget.*|$fp_version|g" go.mod
-          go mod tidy
-
-      - name: Run op e2e tests
-        run: |
-          export PATH=${PATH}:$(go env GOPATH)/bin
-          cd finality-provider
-          make op-e2e-devnet
-          make test-e2e-op

--- a/cwclient/cwclient.go
+++ b/cwclient/cwclient.go
@@ -48,6 +48,11 @@ func (cwClient *CosmWasmClient) QueryListOfVotedFinalityProviders(
 	if err != nil {
 		return nil, err
 	}
+	// BlockVoters's return type is Option<HashSet<String>> in contract
+	// Check empty response before unmarshaling
+	if len(resp.Data) == 0 {
+		return nil, nil
+	}
 
 	votedFpPkHexList := &[]string{}
 	if err := json.Unmarshal(resp.Data, votedFpPkHexList); err != nil {
@@ -114,9 +119,9 @@ func createBlockVotersQueryData(queryParams *types.Block) ([]byte, error) {
 }
 
 type contractConfigResponse struct {
-	ConsumerId      string `json:"consumer_id"`
-	ActivatedHeight uint64 `json:"activated_height"`
+	ConsumerId string `json:"consumer_id"`
 }
+
 type ContractQueryMsgs struct {
 	Config      *contractConfig   `json:"config,omitempty"`
 	BlockVoters *blockVotersQuery `json:"block_voters,omitempty"`


### PR DESCRIPTION
## Summary

We saw the following unmarshalling error in the FG logs. 

```
2024-11-24T01:27:45.282737Z	info	Processing new blocks	{"start_height": 138620, "end_height": 138622}
2024-11-24T01:27:45.282774Z	info	Processing batch of blocks	{"batch_start_height": 138620, "batch_end_height": 138622}
2024-11-24T01:27:46.315131Z	error	Error checking if block is finalized from babylon	{"block_height": 138622, "error": "error in json rpc client, with http response metadata: (Status: 502 Bad Gateway, Protocol HTTP/1.1). error unmarshalling: invalid character 'e' looking for beginning of value"}
2024-11-24T01:27:46.315187Z	fatal	Error processing blocks	{"error": "error processing block 138622: error checking is block 138622 finalized from babylon: error in json rpc client, with http response metadata: (Status: 502 Bad Gateway, Protocol HTTP/1.1). error unmarshalling: invalid character 'e' looking for beginning of value"}
```

Upon checking the code, the error is thrown in the `QueryIsBlockBabylonFinalizedFromBabylon` function, and only cw-related functions involve JSON unmarshalling, this PR checks the response before unmarshaling it.


## Test Plan

```
make lint
make test
```