### PR TITLE
chore: update reusable docker pipeline to v0.16.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - '**'
   workflow_dispatch:
-  
+
 jobs:
   lint_test:
     uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.7.0
@@ -24,7 +24,7 @@ jobs:
 
   docker_pipeline:
     needs: ["lint_test"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@d2299e834fcbaca4bf2db043a2939798043d5951 # v0.16.1
     secrets: inherit
     with:
       publish: true


### PR DESCRIPTION
## Summary

Updates `reusable_docker_pipeline.yml` to v0.16.1 (`d2299e8`).

### What changes in v0.16.1

- **Lint failures block publishing**: `dockerfile_lint` is now a dependency of `docker_build`, so Hadolint failures will block image publishing

### What changed in v0.16.0

- **Scan-before-push**: Trivy filesystem + image scans run before any registry push
- **Secret scanning**: source code and image layer secret detection
- **Scans enabled by default**: `docker_scan: true`, `trivy_nofail: false`, `hadolint_nofail: false`
- **DockerHub push disabled by default**: `push_to_dockerhub` now defaults to `false`
- **Job Summary**: scan results appear directly in the GitHub Actions run summary
- **SARIF upload**: vulnerability findings surface in GitHub Security tab (public repos)
- **Build caching**: scan build layers are reused via `cache-from` for push steps

