### PR TITLE
chore: update reusable docker pipeline to v0.18.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
 
   docker_pipeline:
     needs: ["lint_test"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.1
     secrets: inherit
     with:
       publish: true


### PR DESCRIPTION
## Summary

- Update `reusable_docker_pipeline.yml` to v0.18.1 (`0adff9d36a`)

### What's new in v0.18.1

- Scan-before-push: images are scanned locally before any registry push
- 4-scan model: filesystem vulns, filesystem secrets, image vulns, image secrets
- Secret scanning for source code and Docker layers (CRITICAL, HIGH)
- SARIF upload to GitHub Security tab (public repos)
- Scan results in GitHub Actions Job Summary
- Hadolint lint failures block image publishing