### PR TITLE
chore: upgrade GitHub Actions to latest pinned versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ on:
   
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@5d014a155c08d56a1b5673d049f2b4e7d4427825 # v0.19.0 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     with:
       go-version: "1.23.8"
       run-build: true
@@ -24,7 +24,7 @@ jobs:
 
   docker_pipeline:
     needs: ["lint_test"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5d014a155c08d56a1b5673d049f2b4e7d4427825 # v0.19.0 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     secrets: inherit
     with:
       publish: true


### PR DESCRIPTION
## Summary

- Upgrade all `uses:` references in `.github/workflows/` to the latest full `vX.Y.Z` versions
- Pin each action to its immutable 40-char commit SHA
- Version tag preserved in trailing comment (e.g. `# v6.0.2 https://...`) for readability

## Why

SHA pinning prevents supply-chain attacks: a version tag can be silently force-pushed to malicious code, but a commit SHA is immutable.

## Files changed

-     Files updated: publish.yml
-       - babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
-       - babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
-  .github/workflows/publish.yml | 4 ++--

## Pinned actions

- babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
- babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1